### PR TITLE
fix in motion controllers docs

### DIFF
--- a/docs/examples/20_motion_controllers.md
+++ b/docs/examples/20_motion_controllers.md
@@ -31,7 +31,7 @@ unnecessary clogging up the uplink from the client.
 
 ```python
 from vuer import Vuer, VuerSession
-from vuer.schemas import MotionController
+from vuer.schemas import MotionControllers
 from asyncio import sleep
 
 app = Vuer()
@@ -46,7 +46,7 @@ async def handler(event, session):
 async def main(session: VuerSession):
     # Important: You need to set the `stream` option to `True` to start
     # streaming the controller movement.
-    session.upsert @ MotionController(stream=True, key="motion-controller")
+    session.upsert @ MotionControllers(stream=True, key="motion-controller")
 
     while True:
         await sleep(1)

--- a/docs/examples/20_motion_controllers.py
+++ b/docs/examples/20_motion_controllers.py
@@ -39,7 +39,7 @@ unnecessary clogging up the uplink from the client.
 
 with doc, doc.skip if MAKE_DOCS else nullcontext():
     from vuer import Vuer, VuerSession
-    from vuer.schemas import MotionController
+    from vuer.schemas import MotionControllers
     from asyncio import sleep
 
     app = Vuer()
@@ -54,7 +54,7 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
     async def main(session: VuerSession):
         # Important: You need to set the `stream` option to `True` to start
         # streaming the controller movement.
-        session.upsert @ MotionController(stream=True, key="motion-controller")
+        session.upsert @ MotionControllers(stream=True, key="motion-controller")
 
         while True:
             await sleep(1)


### PR DESCRIPTION
@geyang The example script for the quest motion controllers has a typo in the import from vuer.schemas . The class definition is MotionControllers not MotionController, just fixed that in docs.