### PR TITLE
fix examples

### DIFF
--- a/docs/examples/01_trimesh.md
+++ b/docs/examples/01_trimesh.md
@@ -28,7 +28,7 @@ with open(assets_folder / test_file, "rb") as f:
     data = f.read()
     text = trimesh.util.decode_text(data)
 
-app = Vuer(static_root=assets_folder, port=8013)
+app = Vuer(static_root=assets_folder)
 
 print(f"Loaded mesh with {mesh.vertices.shape} vertices and {mesh.faces.shape} faces")
 
@@ -36,6 +36,7 @@ print(f"Loaded mesh with {mesh.vertices.shape} vertices and {mesh.faces.shape} f
 # use `start=True` to start the app immediately
 @app.spawn(start=True)
 async def main(session):
+
     session @ Set(
         DefaultScene(
             SceneBackground(),
@@ -50,7 +51,6 @@ async def main(session):
                 text=text,
                 position=[1, 0, 1],
                 scale=0.3,
-                materialType="depth",
             ),
             TriMesh(
                 key="trimesh",

--- a/docs/examples/01_trimesh.py
+++ b/docs/examples/01_trimesh.py
@@ -4,6 +4,7 @@ from contextlib import nullcontext
 
 MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
+
 doc @ """
 # Trimesh
 
@@ -35,7 +36,7 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
         data = f.read()
         text = trimesh.util.decode_text(data)
 
-    app = Vuer(static_root=assets_folder, port=8013)
+    app = Vuer(static_root=assets_folder)
 
     print(f"Loaded mesh with {mesh.vertices.shape} vertices and {mesh.faces.shape} faces")
 
@@ -43,6 +44,7 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
     # use `start=True` to start the app immediately
     @app.spawn(start=True)
     async def main(session):
+
         session @ Set(
             DefaultScene(
                 SceneBackground(),
@@ -57,7 +59,6 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
                     text=text,
                     position=[1, 0, 1],
                     scale=0.3,
-                    materialType="depth",
                 ),
                 TriMesh(
                     key="trimesh",

--- a/docs/examples/02_pointcloud.md
+++ b/docs/examples/02_pointcloud.md
@@ -1,3 +1,4 @@
+
 # Showing Point Clouds Programmatically and Fast💨
 
 This example shows you two ways to load a point cloud. In the first example, you serve the point cloud as an `ply` file, and have the webclient read directly from your file system. This approach, however can be a bit slow, and won't work with point cloud data that are updated at real time. In the second example, you load the point cloud into python and then send the parsed vertices and the color information via the `PointCloud` component.
@@ -32,7 +33,7 @@ from vuer.schemas import DefaultScene, Ply, PointCloud
 assets_folder = Path(__file__).parent / "../../../assets"
 test_file = "static_3d/porsche.ply"
 
-# trimesh has issue loading large pointclouds.
+# trimesh has issue loading large point clouds.
 pcd = o3d.io.read_point_cloud(str(assets_folder / test_file))
 
 app = Vuer(static_root=assets_folder)

--- a/docs/examples/02_pointcloud_pcd.md
+++ b/docs/examples/02_pointcloud_pcd.md
@@ -7,6 +7,7 @@ You should expect to see a scene that looks like the following:
 ![pointcloud](figures/pointcloud_pcd.png)
 
 ```python
+import os
 from asyncio import sleep
 
 from vuer import Vuer, VuerSession

--- a/docs/examples/02_pointcloud_pcd.py
+++ b/docs/examples/02_pointcloud_pcd.py
@@ -16,6 +16,7 @@ You should expect to see a scene that looks like the following:
 ![pointcloud](figures/pointcloud_pcd.png)
 """
 with doc, doc.skip if MAKE_DOCS else nullcontext():
+    import os
     from asyncio import sleep
 
     from vuer import Vuer, VuerSession

--- a/docs/examples/04_imperative_api.md
+++ b/docs/examples/04_imperative_api.md
@@ -17,6 +17,7 @@ app = Vuer(
         reconnect=True,
         grid=False,
         backgroundColor="black",
+        
     ),
 )
 
@@ -30,7 +31,7 @@ async def show_heatmap(sess: VuerSession):
         position=[0, 0, 0.1],
         rotation=[0, 0, 0],
         materialType="phong",
-        meterial=dict(color="green"),
+        material=dict(color="green"),
         outlines=dict(angle=0, thickness=0.005, color="white"),
     )
 

--- a/docs/examples/04_imperative_api.py
+++ b/docs/examples/04_imperative_api.py
@@ -23,6 +23,7 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
             reconnect=True,
             grid=False,
             backgroundColor="black",
+            
         ),
     )
 

--- a/docs/examples/05_collecting_render.md
+++ b/docs/examples/05_collecting_render.md
@@ -78,7 +78,7 @@ async def show_heatmap(proxy):
         position=[0, 0, 0.1],
         rotation=[0, 0, 0],
         materialType="depth",
-        meterial=dict(color="green"),
+        material=dict(color="green"),
         outlines=dict(angle=0, thickness=0.005, color="white"),
     )
 
@@ -88,7 +88,7 @@ async def show_heatmap(proxy):
         position=[0, 0, -0.01],
         rotation=[0, 0, 0],
         materialType="depth",
-        meterial=dict(color="green", side=2),
+        material=dict(color="green", side=2),
     )
 
     (

--- a/docs/examples/05_collecting_render.py
+++ b/docs/examples/05_collecting_render.py
@@ -1,7 +1,7 @@
 import os
 from contextlib import nullcontext
 
-MAKE_DOCS = os.getenv("MAKE_DOCS", True)
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 from cmx import doc
 

--- a/docs/examples/05_collecting_render_procedural.md
+++ b/docs/examples/05_collecting_render_procedural.md
@@ -30,7 +30,7 @@ async def show_heatmap(sess: VuerSession):
             position=[0, 0, 0],
             rotation=[0, 0, 0],
             materialType="depth",
-            meterial=dict(color="green", side=2),
+            material=dict(color="green", side=2),
         ),
         Sphere(
             key="sphere",

--- a/docs/examples/05_pointcloud_animation.md
+++ b/docs/examples/05_pointcloud_animation.md
@@ -23,7 +23,6 @@ app = Vuer()
 infill = np.load("assets/suzanne_infill_good_traj.npy")
 surface_infill = np.load("assets/suzanne_surface_fill_only.npy")
 
-
 @app.spawn
 async def main(proxy):
     proxy @ Set(
@@ -36,7 +35,6 @@ async def main(proxy):
 
     while True:
         await asyncio.sleep(1.0)
-
 
 async def frame_handle(e: ClientEvent, _):
     print("frame handle")

--- a/docs/examples/05_pointcloud_animation_upsert.md
+++ b/docs/examples/05_pointcloud_animation_upsert.md
@@ -1,6 +1,7 @@
 
 # Point Cloud Animation (Upsert)
 
+
 ```python
 import asyncio
 from pathlib import Path
@@ -8,7 +9,7 @@ from pathlib import Path
 import numpy as np
 import open3d as o3d
 
-from vuer import Vuer
+from vuer import Vuer, VuerSession
 from vuer.events import Set, ClientEvent
 from vuer.schemas import DefaultScene, TriMesh, PointCloud, TimelineControls
 
@@ -21,7 +22,6 @@ app = Vuer()
 infill = np.load("assets/suzanne_infill_good_traj.npy")
 surface_infill = np.load("assets/suzanne_surface_fill_only.npy")
 
-
 @app.spawn
 async def main(proxy):
     proxy.set @ DefaultScene()
@@ -29,14 +29,13 @@ async def main(proxy):
     while True:
         await asyncio.sleep(1.0)
 
-
-async def frame_handle(e: ClientEvent, _):
+async def frame_handle(e: ClientEvent, proxy: VuerSession):
     print("frame handle")
 
     step = e.value["step"]
     step = step % len(infill)
 
-    app.upsert @ [
+    proxy.upsert(
         TimelineControls(end=len(infill), step=step, speed=1.0, paused=False, key="timeline"),
         PointCloud(key="infill", vertices=infill[step], position=[0, 0, 0], color="red"),
         PointCloud(
@@ -45,6 +44,6 @@ async def frame_handle(e: ClientEvent, _):
             position=[0.8, 0, 0],
             color="green",
         ),
-    ]
+    )
     print("updated the scene")
 ```

--- a/docs/examples/06_depth_texture.md
+++ b/docs/examples/06_depth_texture.md
@@ -14,7 +14,6 @@ from vuer.schemas import Scene, Box, Sphere, group, SceneBackground
 
 app = Vuer()
 
-
 @app.spawn(start=True)
 async def show_heatmap(proxy):
     scene = Scene(

--- a/docs/examples/06_depth_texture.py
+++ b/docs/examples/06_depth_texture.py
@@ -1,4 +1,8 @@
+import os
+from contextlib import nullcontext
 from cmx import doc
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Depth Texture
@@ -8,7 +12,7 @@ There are two types of depth: range and metric depth. Range depth is the distanc
 I have implemented range depth in the deformable image plane. I will add metric depth soon. Please consider adding a GitHub issueto upvote this feature, or contribute via a PR.
 """
 
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
 
     from vuer import Vuer

--- a/docs/examples/07_background_image.md
+++ b/docs/examples/07_background_image.md
@@ -15,7 +15,13 @@ from vuer import Vuer
 from vuer.events import ClientEvent
 from vuer.schemas import Scene, SceneBackground
 
-reader = iio.get_reader("../../../assets/movies/disney.webm")
+assets_folder = Path(__file__).parent / "../../../assets"
+
+disney_file = "movies/disney.webm"
+
+reader_file = assets_folder / disney_file
+
+reader = iio.get_reader(reader_file)
 
 app = Vuer()
 
@@ -45,6 +51,7 @@ async def show_heatmap(session):
                 interpolate=True,
             ),
             to="bgChildren",
+            
         )
         # 'jpeg' encoding should give you about 30fps with a 16ms wait in-between.
         await sleep(0.016)

--- a/docs/examples/07_background_image.py
+++ b/docs/examples/07_background_image.py
@@ -1,4 +1,10 @@
+from pathlib import Path
 from cmx import doc
+import os
+from contextlib import nullcontext
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
+
 
 doc @ """
 # Background Image
@@ -8,7 +14,7 @@ relaying from a rendering model such as NeRFs, Gaussian Splatting, or
 GANs.
 """
 
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
 
     import imageio as iio
@@ -18,7 +24,13 @@ with doc, doc.skip:
     from vuer.events import ClientEvent
     from vuer.schemas import Scene, SceneBackground
 
-    reader = iio.get_reader("../../../assets/movies/disney.webm")
+    assets_folder = Path(__file__).parent / "../../../assets"
+
+    disney_file = "movies/disney.webm"
+
+    reader_file = assets_folder / disney_file
+
+    reader = iio.get_reader(reader_file)
 
     app = Vuer()
 
@@ -48,6 +60,9 @@ with doc, doc.skip:
                     interpolate=True,
                 ),
                 to="bgChildren",
+                
             )
             # 'jpeg' encoding should give you about 30fps with a 16ms wait in-between.
             await sleep(0.016)
+
+doc.flush()

--- a/docs/examples/07b_vr_hud.py
+++ b/docs/examples/07b_vr_hud.py
@@ -1,4 +1,8 @@
 from cmx import doc
+from contextlib import nullcontext
+import os
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Background Image
@@ -11,7 +15,7 @@ This is useful for teleoperating robots with a single camera view.
 ![heads up display (HUD) in VR](figures/07b_vr_hud.png)
 """
 
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
 
     import imageio as iio

--- a/docs/examples/08_experimental_depth_image.md
+++ b/docs/examples/08_experimental_depth_image.md
@@ -28,15 +28,13 @@ app = Vuer(
     static_root=assets_folder,
 )
 
-
 def get_buffer(file_path):
     with open(file_path, "rb") as f:
         file_buffer = f.read()
 
     return file_buffer
 
-
-@app.spawn
+@app.spawn(start=True)
 async def show_heatmap(proxy):
     rgb = get_buffer(assets_folder / "images/cubic_rgb.jpg")
     depth = get_buffer(assets_folder / "images/cubic_depth.jpg")
@@ -57,7 +55,6 @@ async def show_heatmap(proxy):
 
     while True:
         await sleep(10.0)
-
 
 async def on_camera(event: ClientEvent, send_fn):
     assert event == "CAMERA_MOVE", "the event type should be correct"

--- a/docs/examples/08_experimental_depth_image.py
+++ b/docs/examples/08_experimental_depth_image.py
@@ -1,5 +1,11 @@
 from cmx import doc
 
+import os
+
+from contextlib import nullcontext
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
+
 doc @ """
 # RGB-D Visualization
 
@@ -11,7 +17,7 @@ make
 ```
 And this should download a pair of RGB and depth image.
 """
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
     from pathlib import Path
 
@@ -36,7 +42,7 @@ with doc, doc.skip:
 
         return file_buffer
 
-    @app.spawn
+    @app.spawn(start=True)
     async def show_heatmap(proxy):
         rgb = get_buffer(assets_folder / "images/cubic_rgb.jpg")
         depth = get_buffer(assets_folder / "images/cubic_depth.jpg")

--- a/docs/examples/11_coordinates_markers.md
+++ b/docs/examples/11_coordinates_markers.md
@@ -20,12 +20,11 @@ N = 1000
 
 markers = [
     CoordsMarker(
-        position=[i % n, (i // n) % n, (i // n ** 2) % n],
+        position=[i % n, (i // n) % n, (i // n**2) % n],
         scale=0.25,
     )
     for i in range(N)
 ]
-
 
 @app.spawn(start=True)
 async def main(proxy: VuerSession):

--- a/docs/examples/11_coordinates_markers.py
+++ b/docs/examples/11_coordinates_markers.py
@@ -1,4 +1,9 @@
+import os
+from contextlib import nullcontext
 from cmx import doc
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
+
 
 doc @ """
 # Coordinates Markers
@@ -10,7 +15,7 @@ This example visualizes a large number of coordinates markers.
 Live demo: TBD
 """
 
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
 
     from vuer import Vuer, VuerSession

--- a/docs/examples/12_camera.md
+++ b/docs/examples/12_camera.md
@@ -12,10 +12,9 @@ Simply run the following script:
 from vuer import Vuer, VuerSession
 from vuer.schemas import DefaultScene, Frustum
 
-n, N = 12, 12 ** 3
+n, N = 12, 12**3
 
 app = Vuer()
-
 
 @app.spawn(start=True)
 async def main(sess: VuerSession):
@@ -27,10 +26,13 @@ async def main(sess: VuerSession):
                 showImagePlane=True,
                 showFrustum=False,
                 showFocalPlane=False,
-                position=[i % n, (i // n) % n, (i // n ** 2) % n],
+                position=[i % n, (i // n) % n, (i // n**2) % n],
                 rotation=[0.5 * 3.14, 0, 0],
             )
             for i in range(N)
         ]
     )
+
+    while True:
+        await sleep(0.01)
 ```

--- a/docs/examples/12_camera.py
+++ b/docs/examples/12_camera.py
@@ -2,6 +2,10 @@ from pathlib import Path
 
 from cmx import doc
 from asyncio import sleep
+import os
+from contextlib import nullcontext
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 
 async def save_doc():
@@ -26,7 +30,7 @@ doc.image(src=f"figures/{Path(__file__).stem}.jpg", width=400)
 doc @ """
 Simply run the following script:
 """
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from vuer import Vuer, VuerSession
     from vuer.schemas import DefaultScene, Frustum
 
@@ -50,3 +54,6 @@ with doc, doc.skip:
                 for i in range(N)
             ]
         )
+
+        while True:
+            await sleep(0.01)

--- a/docs/examples/13_plane_primitive.md
+++ b/docs/examples/13_plane_primitive.md
@@ -5,6 +5,7 @@ This example shows you how to construct a plane and have it visible on both side
 
 We pass in `Plane.material.side=2` to the `Plane` constructor to make it visible on both sides.
 
+
 ```python
 from asyncio import sleep
 
@@ -13,7 +14,6 @@ from vuer.events import Set
 from vuer.schemas import DefaultScene, Plane
 
 app = Vuer()
-
 
 # use `start=True` to start the app immediately
 @app.spawn(start=True)

--- a/docs/examples/13_plane_primitive.py
+++ b/docs/examples/13_plane_primitive.py
@@ -1,4 +1,8 @@
+import os
+from contextlib import nullcontext
 from cmx import doc
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Plane Primitive
@@ -9,7 +13,7 @@ We pass in `Plane.material.side=2` to the `Plane` constructor to make it visible
 
 """
 
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
 
     from vuer import Vuer

--- a/docs/examples/14_obj.py
+++ b/docs/examples/14_obj.py
@@ -1,6 +1,10 @@
 from pathlib import Path
+import os
+from contextlib import nullcontext
 
 from cmx import doc
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Plane Primitive
@@ -66,7 +70,7 @@ mesh has been loaded: red stairs are loaded
 
 Now to setup the scene, we can bind the main function:
 """
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     # use `start=True` to start the app immediately
     @app.spawn(start=True)
     async def main(session):

--- a/docs/examples/15_spline_frustum.py
+++ b/docs/examples/15_spline_frustum.py
@@ -1,4 +1,9 @@
 from cmx import doc
+from contextlib import nullcontext
+from pathlib import Path
+import os
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Spline and Frustums
@@ -37,7 +42,7 @@ with doc @ "Extract the points from the camera matrices":
     points = matrices[:, [3, 7, 11]]
     three_matrices = colmap2three(matrices)
 
-with doc @ f"Camera path with {len(points)} points", doc.skip:
+with doc @ f"Camera path with {len(points)} points", doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
     from vuer import Vuer
     from vuer.schemas import DefaultScene, Line, Frustum

--- a/docs/examples/17_sky_ball.md
+++ b/docs/examples/17_sky_ball.md
@@ -1,7 +1,7 @@
 
 # Showing 360 Views with a Sky Ball
 
-This example requires a equirectangular image (show below), which is then
+This example requires a equirectangular image (shown below), which is then
 mapped to a sphere as a texture. 
 
 ![equirectangular image](figures/farm_house.jpg)

--- a/docs/examples/17_sky_ball.py
+++ b/docs/examples/17_sky_ball.py
@@ -1,4 +1,10 @@
 from cmx import doc
+from pathlib import Path
+from cmx import doc
+import os
+from contextlib import nullcontext
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Showing 360 Views with a Sky Ball
@@ -15,7 +21,7 @@ try to load from the url `http://localhost:8012/static/farm_house.jpg`.
 Here is the expected result:
 ![marker light](figures/17_sky_ball.png)
 """
-with doc, doc.skip:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
     import numpy as np
 

--- a/docs/examples/19_hand_tracking.py
+++ b/docs/examples/19_hand_tracking.py
@@ -2,7 +2,7 @@ import os
 from cmx import doc
 from contextlib import nullcontext
 
-MAKE_DOCS = os.getenv("MAKE_DOCS", True)
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Hand Tracking

--- a/docs/examples/20_motion_controllers.py
+++ b/docs/examples/20_motion_controllers.py
@@ -3,7 +3,7 @@ from contextlib import nullcontext
 
 from cmx import doc
 
-MAKE_DOCS = os.getenv("MAKE_DOCS", True)
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Quest 3 Motion Controller States

--- a/docs/examples/21_3D_movie.md
+++ b/docs/examples/21_3D_movie.md
@@ -2,7 +2,7 @@
 # Playing 3D Movie in VisionPro and Quest 3
 
 This example shows how to use background images + layers
-to play a 3D movie in the VisionPro and the Quest 3
+to play a 3D movie in the VisionPro and the Quest 3.
 
 Before you start, first run the following script:
 
@@ -14,12 +14,16 @@ wget -O mary.webm https://threejs.org/examples/textures/MaryOculus.webm
 
 ![Side view of the 3D movie screen](figures/21_3D_movie.png)
 
-```{admonition} ImagePlane.layer Property
 The underlying rendering engine supported a layer binary bitmask
 for both objects and the camera. Below we set the two image planes,
 left and right, to `layers=1` and `layers=2`. Note that these two 
 masks are associated with left eye's camera and the right eye's
 camera.
+
+```{admonition} ImagePlane.layer Property
+Pay attention to the layer property. You can set it to 3 to have
+it show up in both eyes! layers=0 is the default, and it appears 
+on all of the cameras.
 ```
 
 
@@ -33,7 +37,12 @@ from vuer import Vuer
 from vuer.events import ClientEvent
 from vuer.schemas import Scene, ImageBackground
 
-reader = iio.get_reader("./mary.webm")
+assets_folder = Path(__file__).parent / "../../../assets"
+mary_file = "movies/mary.webm"
+reader_file = assets_folder / mary_file
+
+
+reader = iio.get_reader(reader_file)
 
 app = Vuer()
 
@@ -43,7 +52,7 @@ async def on_camera(event: ClientEvent, session):
     assert event == "CAMERA_MOVE", "the event type should be correct"
     print("camera event", event.etype, event.value)
 
-@app.spawn(start=True)
+@app.spawn
 async def show_heatmap(session):
     session.set @ Scene()
 
@@ -83,4 +92,13 @@ async def show_heatmap(session):
             )
             # 'jpeg' encoding should give you about 30fps with a 16ms wait in-between.
             await sleep(0.016 * 2)
+```
+
+## Next Steps
+
+- [ ] Add layers support to the virtual cameras.
+
+
+```python
+app.run()
 ```

--- a/docs/examples/21_3D_movie.md
+++ b/docs/examples/21_3D_movie.md
@@ -52,7 +52,7 @@ async def on_camera(event: ClientEvent, session):
     assert event == "CAMERA_MOVE", "the event type should be correct"
     print("camera event", event.etype, event.value)
 
-@app.spawn
+@app.spawn(start=True)
 async def show_heatmap(session):
     session.set @ Scene()
 
@@ -98,7 +98,3 @@ async def show_heatmap(session):
 
 - [ ] Add layers support to the virtual cameras.
 
-
-```python
-app.run()
-```

--- a/docs/examples/21_3D_movie.py
+++ b/docs/examples/21_3D_movie.py
@@ -1,4 +1,9 @@
 from cmx import doc
+import os
+from contextlib import nullcontext
+from pathlib import Path
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
 # Playing 3D Movie in VisionPro and Quest 3
@@ -30,7 +35,7 @@ on all of the cameras.
 
 """
 
-with doc, doc.skip:
+with doc:
     from asyncio import sleep
 
     import imageio as iio
@@ -40,7 +45,12 @@ with doc, doc.skip:
     from vuer.events import ClientEvent
     from vuer.schemas import Scene, ImageBackground
 
-    reader = iio.get_reader("./mary.webm")
+    assets_folder = Path(__file__).parent / "../../../assets"
+    mary_file = "movies/mary.webm"
+    reader_file = assets_folder / mary_file
+
+
+    reader = iio.get_reader(reader_file)
 
     app = Vuer()
 
@@ -50,7 +60,7 @@ with doc, doc.skip:
         assert event == "CAMERA_MOVE", "the event type should be correct"
         print("camera event", event.etype, event.value)
 
-    @app.spawn(start=True)
+    @app.spawn
     async def show_heatmap(session):
         session.set @ Scene()
 
@@ -98,3 +108,7 @@ doc @ """
 - [ ] Add layers support to the virtual cameras.
 
 """
+with doc, doc.skip if MAKE_DOCS else nullcontext():
+    app.run()
+
+doc.flush()

--- a/docs/examples/21_3D_movie.py
+++ b/docs/examples/21_3D_movie.py
@@ -35,7 +35,7 @@ on all of the cameras.
 
 """
 
-with doc:
+with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep
 
     import imageio as iio
@@ -60,7 +60,7 @@ with doc:
         assert event == "CAMERA_MOVE", "the event type should be correct"
         print("camera event", event.etype, event.value)
 
-    @app.spawn
+    @app.spawn(start=True)
     async def show_heatmap(session):
         session.set @ Scene()
 
@@ -108,7 +108,5 @@ doc @ """
 - [ ] Add layers support to the virtual cameras.
 
 """
-with doc, doc.skip if MAKE_DOCS else nullcontext():
-    app.run()
 
 doc.flush()

--- a/docs/examples/22_3d_text.py
+++ b/docs/examples/22_3d_text.py
@@ -2,6 +2,8 @@ import os
 from contextlib import nullcontext
 from cmx import doc
 
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
+
 doc @ """
 # 3D Text in Vuer
 
@@ -10,8 +12,6 @@ The Text3D component renders 3D text using ThreeJS's TextGeometry.
 
 ![3D Text Example](figures/22_3d_text.png)
 """
-
-MAKE_DOCS = os.getenv("MAKE_DOCS", False)
 
 with doc, doc.skip if MAKE_DOCS else nullcontext():
     from asyncio import sleep


### PR DESCRIPTION
Complete the file content adjustment in the example directory to achieve the local environment quick startup function

updates：

1. The asset resource paths are uniformly adjusted to relative paths, eliminating the reliance on absolute paths and improving code portability
2. Set the default value of `MAKE_DOCS` to `None`, and set environment variables locally to determine whether it is document mode or application mode
3. Regenerate md files