### PR TITLE
Using in-browser mujoco as an interactive simulator for robots

### DIFF
--- a/docs/examples/24_mujoco_interactive_simulator.md
+++ b/docs/examples/24_mujoco_interactive_simulator.md
@@ -1,0 +1,110 @@
+
+# Using in-browser mujoco as an interactive simulator for robots
+
+This example shows you how to use the MuJoCo component in Vuer to create an interactive simulation of a car model.
+
+
+```python
+from asyncio import sleep, Queue, create_task, gather
+from pathlib import Path
+
+import numpy as np
+
+from vuer import Vuer
+from vuer.events import MjStep, Set, MjRender
+from vuer.schemas import DefaultScene, SceneBackground, MjCameraView
+from vuer.schemas import MuJoCo
+from PIL import Image as PImage
+from io import BytesIO
+import cv2
+
+app = Vuer(static_root=f"{Path(__file__).parent}/../_static/mujoco_scenes")
+
+asset_pref = "http://localhost:8012/static/"
+
+IS_MUJOCO_LOAD = False
+
+@app.add_handler("ON_MUJOCO_LOAD")
+async def handler(event, session):
+    global IS_MUJOCO_LOAD
+    IS_MUJOCO_LOAD = True
+    print("MuJoCo component loaded successfully.")
+
+result_queue = Queue()
+
+async def process_results():
+    while True:
+        result = await (await result_queue.get())
+        try:
+            if hasattr(result, 'value') and isinstance(result.value, dict):
+                frame = result.value.get("depthFrame") or result.value.get("frame")
+                if frame:
+                    pil_image = PImage.open(BytesIO(frame))
+                    img = np.array(pil_image)
+                    img_bgr = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+                    cv2.imshow("monitor", img_bgr)
+                    if cv2.waitKey(1) == ord("q"):
+                        exit()
+                else:
+                    print("No valid frame data found in result.")
+            else:
+                print("Invalid result structure or missing 'value' attribute.")
+        except Exception as e:
+            print(f"Error processing result: {e}")
+
+# use `start=True` to start the app immediately
+@app.spawn(start=True)
+async def main(session):
+    session @ Set(
+        DefaultScene(
+            SceneBackground(),
+            MuJoCo(
+                key="simple",
+                src=asset_pref + "car/car.mjcf.xml",
+                pause=False,
+                useLights=True,
+                dragAble=False,
+            ),
+            MjCameraView(
+                key="cam1",
+                position=[0, 0.35, 0.5],
+                rotation=[-0.4, 0, 0],
+                width=640,
+                height=480,
+                stream="ondemand",
+                distanceToCamera=0.1,
+            ),
+
+            up=[0, 1, 0],
+            show_helper=False
+        ),
+    )
+    await sleep(2)
+
+    create_task(process_results())
+
+    i = 0
+    while True:
+        i += 1
+        if not IS_MUJOCO_LOAD:
+            print("Waiting for MuJoCo component to load...")
+            await sleep(1)
+            continue
+
+        await session.rpc(MjStep(
+            key="simple",
+            sim_steps=5,
+            ctrl=[np.clip(np.sin(i * 0.1), -1, 1), 1]
+        ), ttl=5)
+
+        """
+        Instead of waiting for the rendering result, we can use a queue to handle the rendering tasks like the code below.
+        Or you can using 
+            `await session.rpc_no_wait(MjRender(key="cam1"))`
+        to send the rendering task without waiting for the result directly. It is the same as the direct "send" event.
+        """
+        result_task = session.rpc(MjRender(key="cam1"))
+        await result_queue.put(result_task)
+
+        await sleep(1 / 30)
+```

--- a/docs/examples/24_mujoco_interactive_simulator.md
+++ b/docs/examples/24_mujoco_interactive_simulator.md
@@ -5,7 +5,7 @@ This example shows you how to use the MuJoCo component in Vuer to create an inte
 
 
 ```python
-from asyncio import sleep, Queue, create_task, gather
+from asyncio import sleep, Queue, create_task
 from pathlib import Path
 
 import numpy as np
@@ -22,7 +22,7 @@ app = Vuer(static_root=f"{Path(__file__).parent}/../_static/mujoco_scenes")
 
 asset_pref = "http://localhost:8012/static/"
 
-IS_MUJOCO_LOAD = False
+IS_MUJOCO_LOAD = True
 
 @app.add_handler("ON_MUJOCO_LOAD")
 async def handler(event, session):
@@ -36,7 +36,7 @@ async def process_results():
     while True:
         result = await (await result_queue.get())
         try:
-            if hasattr(result, 'value') and isinstance(result.value, dict):
+            if hasattr(result, "value") and isinstance(result.value, dict):
                 frame = result.value.get("depthFrame") or result.value.get("frame")
                 if frame:
                     pil_image = PImage.open(BytesIO(frame))
@@ -63,7 +63,10 @@ async def main(session):
                 src=asset_pref + "car/car.mjcf.xml",
                 pause=False,
                 useLights=True,
-                dragAble=False,
+                unpauseOnDrag=False, # Whether to unpause the simulation when dragging the object
+                dragForceScale=1.0, # Scale of the drag force applied to the object when dragging
+                showDragArrow=True, # Whether to show the drag arrow when dragging the object
+                showDragForceText=True, # Whether to show the drag force text when dragging the object
             ),
             MjCameraView(
                 key="cam1",
@@ -71,12 +74,12 @@ async def main(session):
                 rotation=[-0.4, 0, 0],
                 width=640,
                 height=480,
-                stream="ondemand",
                 distanceToCamera=0.1,
+                movable=True, # Whether the camera can be moved by the user
+                showCameraFrustum=True, # Whether to show the camera  in the scene
             ),
-
             up=[0, 1, 0],
-            show_helper=False
+            show_helper=False,
         ),
     )
     await sleep(2)
@@ -91,20 +94,40 @@ async def main(session):
             await sleep(1)
             continue
 
-        await session.rpc(MjStep(
-            key="simple",
-            sim_steps=5,
-            ctrl=[np.clip(np.sin(i * 0.1), -1, 1), 1]
-        ), ttl=5)
+        await session.rpc(
+            MjStep(key="le-cart", sim_steps=10, ctrl=[1, -1]),
+            ttl=5,
+        )
 
         """
-        Instead of waiting for the rendering result, we can use a queue to handle the rendering tasks like the code below.
-        Or you can using 
-            `await session.rpc_no_wait(MjRender(key="cam1"))`
-        to send the rendering task without waiting for the result directly. It is the same as the direct "send" event.
+        Instead of waiting for the rendering result, we can use a queue to handle the 
+        rendering tasks as follows:
         """
-        result_task = session.rpc(MjRender(key="cam1"))
-        await result_queue.put(result_task)
+        with doc:
+            promise = session.rpc(MjRender(key="cam1"))
+            await result_queue.put(promise)
 
         await sleep(1 / 30)
 ```
+
+Alternatively, you can use
+```python
+result = await session.rpc(MjRender(key="cam1"), ttl=5)
+try:
+    if hasattr(result, "value") and isinstance(result.value, dict):
+        frame = result.value.get("depthFrame") or result.value.get("frame")
+        if frame:
+            pil_image = PImage.open(BytesIO(frame))
+            img = np.array(pil_image)
+            img_bgr = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            cv2.imshow("monitor", img_bgr)
+            if cv2.waitKey(1) == ord("q"):
+                exit()
+        else:
+            print("No valid frame data found in result.")
+    else:
+        print("Invalid result structure or missing 'value' attribute.")
+except Exception as e:
+    print(f"Error processing result: {e}")
+```
+to waiting for the rendering result directly, but using a queue is more efficient for handling multiple rendering tasks.

--- a/docs/examples/24_mujoco_interactive_simulator.py
+++ b/docs/examples/24_mujoco_interactive_simulator.py
@@ -1,0 +1,115 @@
+import os
+from cmx import doc
+from contextlib import nullcontext
+
+MAKE_DOCS = os.getenv("MAKE_DOCS", None)
+
+doc @ """
+# Using in-browser mujoco as an interactive simulator for robots
+
+This example shows you how to use the MuJoCo component in Vuer to create an interactive simulation of a car model.
+
+"""
+with doc, doc.skip if MAKE_DOCS else nullcontext():
+    from asyncio import sleep, Queue, create_task, gather
+    from pathlib import Path
+
+    import numpy as np
+
+    from vuer import Vuer
+    from vuer.events import MjStep, Set, MjRender
+    from vuer.schemas import DefaultScene, SceneBackground, MjCameraView
+    from vuer.schemas import MuJoCo
+    from PIL import Image as PImage
+    from io import BytesIO
+    import cv2
+
+    app = Vuer(static_root=f"{Path(__file__).parent}/../_static/mujoco_scenes")
+
+    asset_pref = "http://localhost:8012/static/"
+
+    IS_MUJOCO_LOAD = False
+
+    @app.add_handler("ON_MUJOCO_LOAD")
+    async def handler(event, session):
+        global IS_MUJOCO_LOAD
+        IS_MUJOCO_LOAD = True
+        print("MuJoCo component loaded successfully.")
+
+    result_queue = Queue()
+
+    async def process_results():
+        while True:
+            result = await (await result_queue.get())
+            try:
+                if hasattr(result, 'value') and isinstance(result.value, dict):
+                    frame = result.value.get("depthFrame") or result.value.get("frame")
+                    if frame:
+                        pil_image = PImage.open(BytesIO(frame))
+                        img = np.array(pil_image)
+                        img_bgr = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+                        cv2.imshow("monitor", img_bgr)
+                        if cv2.waitKey(1) == ord("q"):
+                            exit()
+                    else:
+                        print("No valid frame data found in result.")
+                else:
+                    print("Invalid result structure or missing 'value' attribute.")
+            except Exception as e:
+                print(f"Error processing result: {e}")
+
+    # use `start=True` to start the app immediately
+    @app.spawn(start=True)
+    async def main(session):
+        session @ Set(
+            DefaultScene(
+                SceneBackground(),
+                MuJoCo(
+                    key="simple",
+                    src=asset_pref + "car/car.mjcf.xml",
+                    pause=False,
+                    useLights=True,
+                    dragAble=False,
+                ),
+                MjCameraView(
+                    key="cam1",
+                    position=[0, 0.35, 0.5],
+                    rotation=[-0.4, 0, 0],
+                    width=640,
+                    height=480,
+                    stream="ondemand",
+                    distanceToCamera=0.1,
+                ),
+
+                up=[0, 1, 0],
+                show_helper=False
+            ),
+        )
+        await sleep(2)
+
+        create_task(process_results())
+
+        i = 0
+        while True:
+            i += 1
+            if not IS_MUJOCO_LOAD:
+                print("Waiting for MuJoCo component to load...")
+                await sleep(1)
+                continue
+
+            await session.rpc(MjStep(
+                key="simple",
+                sim_steps=5,
+                ctrl=[np.clip(np.sin(i * 0.1), -1, 1), 1]
+            ), ttl=5)
+
+            """
+            Instead of waiting for the rendering result, we can use a queue to handle the rendering tasks like the code below.
+            Or you can using 
+                `await session.rpc_no_wait(MjRender(key="cam1"))`
+            to send the rendering task without waiting for the result directly. It is the same as the direct "send" event.
+            """
+            result_task = session.rpc(MjRender(key="cam1"))
+            await result_queue.put(result_task)
+
+            await sleep(1 / 30)

--- a/docs/examples/24_mujoco_interactive_simulator.py
+++ b/docs/examples/24_mujoco_interactive_simulator.py
@@ -11,7 +11,7 @@ This example shows you how to use the MuJoCo component in Vuer to create an inte
 
 """
 with doc, doc.skip if MAKE_DOCS else nullcontext():
-    from asyncio import sleep, Queue, create_task, gather
+    from asyncio import sleep, Queue, create_task
     from pathlib import Path
 
     import numpy as np
@@ -28,7 +28,7 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
 
     asset_pref = "http://localhost:8012/static/"
 
-    IS_MUJOCO_LOAD = False
+    IS_MUJOCO_LOAD = True
 
     @app.add_handler("ON_MUJOCO_LOAD")
     async def handler(event, session):
@@ -42,7 +42,7 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
         while True:
             result = await (await result_queue.get())
             try:
-                if hasattr(result, 'value') and isinstance(result.value, dict):
+                if hasattr(result, "value") and isinstance(result.value, dict):
                     frame = result.value.get("depthFrame") or result.value.get("frame")
                     if frame:
                         pil_image = PImage.open(BytesIO(frame))
@@ -69,7 +69,10 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
                     src=asset_pref + "car/car.mjcf.xml",
                     pause=False,
                     useLights=True,
-                    dragAble=False,
+                    unpauseOnDrag=False, # Whether to unpause the simulation when dragging the object
+                    dragForceScale=1.0, # Scale of the drag force applied to the object when dragging
+                    showDragArrow=True, # Whether to show the drag arrow when dragging the object
+                    showDragForceText=True, # Whether to show the drag force text when dragging the object
                 ),
                 MjCameraView(
                     key="cam1",
@@ -77,12 +80,12 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
                     rotation=[-0.4, 0, 0],
                     width=640,
                     height=480,
-                    stream="ondemand",
                     distanceToCamera=0.1,
+                    movable=True, # Whether the camera can be moved by the user
+                    showCameraFrustum=True, # Whether to show the camera  in the scene
                 ),
-
                 up=[0, 1, 0],
-                show_helper=False
+                show_helper=False,
             ),
         )
         await sleep(2)
@@ -97,19 +100,43 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
                 await sleep(1)
                 continue
 
-            await session.rpc(MjStep(
-                key="simple",
-                sim_steps=5,
-                ctrl=[np.clip(np.sin(i * 0.1), -1, 1), 1]
-            ), ttl=5)
+            await session.rpc(
+                MjStep(key="le-cart", sim_steps=10, ctrl=[1, -1]),
+                ttl=5,
+            )
 
             """
-            Instead of waiting for the rendering result, we can use a queue to handle the rendering tasks like the code below.
-            Or you can using 
-                `await session.rpc_no_wait(MjRender(key="cam1"))`
-            to send the rendering task without waiting for the result directly. It is the same as the direct "send" event.
+            Instead of waiting for the rendering result, we can use a queue to handle the 
+            rendering tasks as follows:
             """
-            result_task = session.rpc(MjRender(key="cam1"))
-            await result_queue.put(result_task)
+            with doc:
+                promise = session.rpc(MjRender(key="cam1"))
+                await result_queue.put(promise)
 
             await sleep(1 / 30)
+
+doc @ """
+Alternatively, you can use
+```python
+result = await session.rpc(MjRender(key="cam1"), ttl=5)
+try:
+    if hasattr(result, "value") and isinstance(result.value, dict):
+        frame = result.value.get("depthFrame") or result.value.get("frame")
+        if frame:
+            pil_image = PImage.open(BytesIO(frame))
+            img = np.array(pil_image)
+            img_bgr = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+            cv2.imshow("monitor", img_bgr)
+            if cv2.waitKey(1) == ord("q"):
+                exit()
+        else:
+            print("No valid frame data found in result.")
+    else:
+        print("Invalid result structure or missing 'value' attribute.")
+except Exception as e:
+    print(f"Error processing result: {e}")
+```
+to waiting for the rendering result directly, but using a queue is more efficient for handling multiple rendering tasks.
+"""
+
+doc.flush()

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,7 @@ For a comprehensive list of data types, please refer to the [API documentation o
    Quest 3 Controllers <examples/20_motion_controllers.md>
    3D Movie <examples/21_3D_movie.md>
    Raycasted 3D Pointer <examples/21_pointer_example>
+   Mujoco Interactive Simulator <examples/24_mujoco_interactive_simulator>
    
 .. toctree::
    :maxdepth: 3

--- a/vuer/events.py
+++ b/vuer/events.py
@@ -305,6 +305,29 @@ class GrabRender(ServerRPC):
         self.key = key
         self.rtype = f"GRAB_RENDER_RESPONSE@{self.uuid}"
 
+class MjStep(ServerRPC):
+    """
+    A higher-level ServerEvent that wraps other ServerEvents
+    """
+
+    etype = "MJ_STEP"
+
+    def __init__(self, *, key: str = "DEFAULT", **kwargs):
+        super().__init__(data=kwargs)
+        self.key = key
+        self.rtype = f"MJ_STEP_RESPONSE@{self.uuid}"
+
+class MjRender(ServerRPC):
+    """
+    A higher-level ServerEvent that wraps other ServerEvents
+    """
+
+    etype = "MJ_RENDER"
+
+    def __init__(self, *, key: str = "DEFAULT", **kwargs):
+        super().__init__(data=kwargs)
+        self.key = key
+        self.rtype = f"MJ_RENDER_RESPONSE@{self.uuid}"
 
 if __name__ == "__main__":
     # e = Frame @ {"hey": "yo"}

--- a/vuer/schemas/physics_components.py
+++ b/vuer/schemas/physics_components.py
@@ -30,6 +30,11 @@ class MuJoCo(SceneElement):
     useMocap = True
     gizmoScale = 0.3
 
+    unpauseOnDrag = False,  # Whether to unpause the simulation when dragging the object
+    dragForceScale = 1.0,  # Scale of the drag force applied to the object when dragging
+    showDragArrow = True,  # Whether to show the drag arrow when dragging the object
+    showDragForceText = True,  # Whether to show the drag force text when dragging the object
+
 
 class HandActuator(SceneElement):
     tag = "HandActuator"
@@ -92,6 +97,12 @@ class MjCameraView(SceneElement):
     :type downsample: int, optional
     :param distanceToCamera: The distance to the camera. Defaults to 2.
     :type distanceToCamera: float, optional
+    :param movable: Whether the camera can be moved by the user. Defaults to True.
+    :type movable: bool, optional
+    :param showCameraFrustum: Whether to show the camera frustum in the scene. Defaults to True.
+    :type showCameraFrustum: bool, optional
     """
 
     tag = "MjCameraView"
+    movable = True,  # Whether the camera can be moved by the user
+    showCameraFrustum = True,  # Whether to show the camera  in the scene

--- a/vuer/schemas/physics_components.py
+++ b/vuer/schemas/physics_components.py
@@ -66,3 +66,32 @@ class MotionControllerActuator(SceneElement):
     high: float = 1.0
     cond: str = "right-trigger"
     scale: float = 1.0
+
+class MjCameraView(SceneElement):
+    """MjCameraView for rendering from arbitrary camera poses.
+
+    :param fov: The vertical field of view of the camera. Defaults to 50.
+    :type fov: float, optional
+    :param width: The width of the camera image. Defaults to 320.
+    :type width: int, optional
+    :param height: The height of the camera image. Defaults to 240.
+    :type height: int, optional
+    :param key: The key of the camera view. Defaults to "ego".
+    :type key: str, optional
+    :param position: The position of the camera. Defaults to [0, 0, 0].
+    :type position: List[float], optional
+    :param rotation: The rotation of the camera. Defaults to [0, 0, 0]
+    :type rotation: List[float], optional
+    :param fps: The frames per second of the camera. Defaults to 30.
+    :type fps: int, optional
+    :param near: The near field of the camera. Defaults to 0.1.
+    :type near: float, optional
+    :param far: The far field of the camera. Defaults to 20.
+    :type far: float, optional
+    :param downsample: The downsample rate. Defaults to 1.
+    :type downsample: int, optional
+    :param distanceToCamera: The distance to the camera. Defaults to 2.
+    :type distanceToCamera: float, optional
+    """
+
+    tag = "MjCameraView"

--- a/vuer/server.py
+++ b/vuer/server.py
@@ -112,6 +112,68 @@ class VuerSession:
 
         return await self.vuer.rpc(self.CURRENT_WS_ID, event, ttl=ttl)
 
+    async def rpc_no_wait(self, event: ServerRPC, immediately=False) -> None:
+        """
+        Send a ServerRPC event to the client without waiting for a response.
+
+        :param immediately: If True, send the event immediately without waiting for the uplink queue.
+        :param event: The ServerRPC event to send.
+        :return: None
+        """
+        assert self.CURRENT_WS_ID is not None, "Websocket session is missing. CURRENT_WS_ID is None."
+
+        if event.rtype:
+            event.rtype = None
+
+        event_obj = event.serialize()
+        event_bytes = packb(event_obj, use_single_float=True, use_bin_type=True)
+
+        # note: by-pass the uplink message queue entirely, rendering it immune
+        #   to the effects of queue length.
+        if immediately:
+            return await self.vuer.send(self.CURRENT_WS_ID, event_bytes=event_bytes)
+        else:
+            return self.uplink_queue.append(event_bytes)
+
+    async def rpc(self, event: ServerRPC, ttl=2.0, immediately=False) -> Union[ClientEvent, None]:
+        """
+        Send a ServerRPC event to the client and wait for a response.
+        :param immediately: If True, send the event immediately without waiting for the uplink queue.
+        :param event: The ServerRPC event to send.
+        :param ttl: The time to live for the handler. If the handler is not called within the time it gets removed from the handler list.
+        :return: ClientEvent
+        """
+        rtype = event.rtype
+
+        rpc_event = asyncio.Event()
+        response = None
+
+        async def response_handler(response_event: ClientEvent, _: "VuerSession") -> None:
+            nonlocal response
+
+            response = response_event
+            rpc_event.set()
+
+        # handle timeout
+        clean = self.vuer.add_handler(rtype, response_handler, once=True)
+
+        event_obj = event.serialize()
+        event_bytes = packb(event_obj, use_single_float=True, use_bin_type=True)
+        # note: by-pass the uplink message queue entirely, rendering it immune
+        #   to the effects of queue length.
+        if immediately:
+            await self.vuer.send(self.CURRENT_WS_ID, event_bytes=event_bytes)
+        else:
+            self.uplink_queue.append(event_bytes)
+        # await sleep(0.5)
+        try:
+            await asyncio.wait_for(rpc_event.wait(), ttl)
+        except asyncio.TimeoutError as e:
+            clean()
+            raise e
+
+        return response
+
     @property
     def set(self) -> At:
         """Used exclusively to set the scene.


### PR DESCRIPTION
https://github.com/user-attachments/assets/76a8851b-c28a-444a-b469-bb8476766d90


---

**Why do we need to create a separate `rpc` method under `VuerSession` instead of using the `rpc` method on `Vuer` directly?**

The `rpc` method on `Vuer` always bypasses the `uplink_queue` mechanism, meaning events are sent through the WebSocket as quickly as possible. However, this cannot guarantee the correct order of events. We need a way to send RPC requests through the `uplink_queue` to ensure proper sequencing. Since the `uplink_queue` can only be accessed via `VuerSession`, we implement a custom `rpc` method in `VuerSession`, and provide an `immediately` option to control whether the request should be sent through the `uplink_queue`.
