### PR TITLE
feat: Add 3d/2d Text example

### DIFF
--- a/docs/examples/22_3d_text.md
+++ b/docs/examples/22_3d_text.md
@@ -1,10 +1,14 @@
 
-# 3D Text in Vuer
+# 3D Text, 2D Text, and Billboard in Vuer
 
-This example demonstrates how to create and customize 3D text in Vuer using the Text3D component.
-The Text3D component renders 3D text using ThreeJS's TextGeometry.
+This example demonstrates how to create and customize 3D text in Vuer using the Text3D component, as well as how to display 2D text (Text component) and always-face-camera labels (Billboard component).
 
-![3D Text Example](figures/22_3d_text.png)
+- **Text3D** renders 3D text using ThreeJS's TextGeometry.
+- **Text** displays 2D text, suitable for labels and annotations.
+- **Billboard** ensures its children always face the camera, useful for floating labels.
+
+<iframe src="https://vuer.ai/?background=131416,fff&collapseMenu=true&scene=3gAHqGNoaWxkcmVuld4ADahjaGlsZHJlbpKrSGVsbG8gVnVlciHeAAKjdGFnsm1lc2hOb3JtYWxNYXRlcmlhbKNrZXmiNDGjdGFnplRleHQzRKNrZXmnd2VsY29tZaRmb2502UBodHRwczovL3RocmVlanMub3JnL2V4YW1wbGVzL2ZvbnRzL2hlbHZldGlrZXJfYm9sZC50eXBlZmFjZS5qc29upnNtb290aMCqbGluZUhlaWdodACtbGV0dGVyU3BhY2luZ8u%2FmZmZoAAAAKxiZXZlbEVuYWJsZWTDqWJldmVsU2l6Zcs%2FpHrhQAAAAK5iZXZlbFRoaWNrbmVzc8s%2FuZmZoAAAAKRzaXplyz%2F4AAAAAAAApWNvbG9yo3JlZKVzY2FsZcs%2FwzMzQAAAAN4ABqhjaGlsZHJlbpGqRml4ZWQgVGV4dKN0YWekVGV4dKNrZXmqZml4ZWQtdGV4dKVjb2xvcqVncmVlbqhmb250U2l6Zcs%2FuZmZoAAAAKhwb3NpdGlvbpMAyz%2FTMzNAAAAA%2F94AB6hjaGlsZHJlbpHeAAeoY2hpbGRyZW6RrkJpbGxib2FyZCBUZXh0o3RhZ6RUZXh0o2tlea5iaWxsYm9hcmQtdGV4dKVjb2xvcqNyZWSoZm9udFNpemXLP7mZmaAAAAClc2NhbGXLP%2BAAAAAAAACocG9zaXRpb26Tyz%2FTMzNAAAAAyz%2FpmZmgAAAAAKN0YWepQmlsbGJvYXJko2tleaI0MqZmb2xsb3fDpWxvY2tYwqVsb2NrWcKlbG9ja1rC3gAEqGNoaWxkcmVukKN0YWesQW1iaWVudExpZ2h0o2tlea1hbWJpZW50X2xpZ2h0qWludGVuc2l0eQLeAAWoY2hpbGRyZW6Qo3RhZ7BEaXJlY3Rpb25hbExpZ2h0o2tlebFkaXJlY3Rpb25hbF9saWdodKlpbnRlbnNpdHkBqHBvc2l0aW9ukwECAqN0YWelU2NlbmWja2V5ojQ1onVwkwABAKtyYXdDaGlsZHJlbpLeAASoY2hpbGRyZW6Qo3RhZ6xBbWJpZW50TGlnaHSja2V5tWRlZmF1bHRfYW1iaWVudF9saWdodKlpbnRlbnNpdHnLP%2BAAAAAAAADeAAWoY2hpbGRyZW6Qo3RhZ7BEaXJlY3Rpb25hbExpZ2h0o2tleblkZWZhdWx0X2RpcmVjdGlvbmFsX2xpZ2h0qWludGVuc2l0eQGmaGVscGVyw6xodG1sQ2hpbGRyZW6QqmJnQ2hpbGRyZW6T3gADqGNoaWxkcmVukKN0YWeqR3JhYlJlbmRlcqNrZXmnREVGQVVMVN4AA6hjaGlsZHJlbpCjdGFnr1BvaW50ZXJDb250cm9sc6NrZXmiNDPeAAOoY2hpbGRyZW6Qo3RhZ6RHcmlko2tleaI0NA%3D%3D" width="100%" height="400px" frameborder="0"></iframe>
+
 
 ```python
 from asyncio import sleep
@@ -12,57 +16,48 @@ from asyncio import sleep
 from vuer import Vuer
 from vuer.schemas import (
     Text3D,
-    Center,
     DefaultScene,
-    Group,
-    Box,
     AmbientLight,
     DirectionalLight,
+    Text,
+    Billboard,
+    MeshNormalMaterial,
 )
 
 app = Vuer()
+
 
 @app.spawn(start=True)
 async def show_3d_text(session):
     # Create a scene with some basic elements
     session.set @ DefaultScene(
-        # Basic 3D text example
-        Center(
-            Text3D(
-                "Hello Vuer!",
-                font="https://threejs.org/examples/fonts/helvetiker_regular.typeface.json",
-                smooth=1,
-                position=[0, 1, 0],
-                color="blue",
-                scale=0.2,
-            ),
-            key="centered-text",
-        ),
         # Customized 3D text with different parameters
-        Group(
-            Text3D(
-                "Custom Text",
-                font="https://threejs.org/examples/fonts/helvetiker_bold.typeface.json",
-                smooth=0.5,
-                lineHeight=0.5,
-                letterSpacing=-0.025,
-                position=[0, 0, 0],
-                color="red",
-                scale=0.15,
-            ),
-            position=[0, -0.5, 0],
-            key="custom-text",
+        Text3D(
+            "Hello Vuer!",
+            MeshNormalMaterial(),
+            font="https://threejs.org/examples/fonts/helvetiker_bold.typeface.json",
+            bevelEnabled=True,
+            bevelSize=0.04,
+            bevelThickness=0.1,
+            size=1.5,
+            letterSpacing=-0.025,
+            color="red",
+            scale=0.15,
+            key="welcome",
         ),
-        # A small platform below the text
-        Box(
-            width=3,
-            height=0.1,
-            depth=1,
-            position=[0, -1, 0],
-            color="#888888",
+        Text('Fixed Text', color='green', fontSize=0.1, position=[0, 0.3, -1], key="fixed-text"),
+        Billboard(
+            Text(
+                'Billboard Text',
+                color="red",
+                fontSize=0.1,
+                scale=0.5,
+                position=[0.3, 0.8, 0],
+                key="billboard-text",
+            )
         ),
         # Add lighting to make the text visible
-        AmbientLight(intensity=0.5, key="ambient_light"),
+        AmbientLight(intensity=2, key="ambient_light"),
         DirectionalLight(intensity=1, position=[1, 2, 2], key="directional_light"),
     )
     await sleep(0.1)
@@ -70,7 +65,24 @@ async def show_3d_text(session):
     # Demo of rotating text
     angle = 0
     while True:
-        angle += 0.1
-        session.update @ Group(rotation=[0, angle, 0], key="custom-text")
-        await sleep(0.05)
+        angle += 0.01
+
+        session.update([
+            Text3D(
+                "Hello Vuer!",
+                MeshNormalMaterial(),
+                font="https://threejs.org/examples/fonts/helvetiker_bold.typeface.json",
+                bevelEnabled=True,
+                bevelSize=0.04,
+                bevelThickness=0.1,
+                size=1,
+                letterSpacing=-0.025,
+                color="red",
+                scale=0.1,
+                key="welcome",
+                rotation=[0, angle, 0]
+            ),
+            Text('Angle: ' + f'{angle:.2f}', key="fixed-text"),
+        ]),
+        await sleep(0.032)
 ```

--- a/docs/examples/22_3d_text.py
+++ b/docs/examples/22_3d_text.py
@@ -5,12 +5,16 @@ from cmx import doc
 MAKE_DOCS = os.getenv("MAKE_DOCS", None)
 
 doc @ """
-# 3D Text in Vuer
+# 3D Text, 2D Text, and Billboard in Vuer
 
-This example demonstrates how to create and customize 3D text in Vuer using the Text3D component.
-The Text3D component renders 3D text using ThreeJS's TextGeometry.
+This example demonstrates how to create and customize 3D text in Vuer using the Text3D component, as well as how to display 2D text (Text component) and always-face-camera labels (Billboard component).
 
-![3D Text Example](figures/22_3d_text.png)
+- **Text3D** renders 3D text using ThreeJS's TextGeometry.
+- **Text** displays 2D text, suitable for labels and annotations.
+- **Billboard** ensures its children always face the camera, useful for floating labels.
+
+<iframe src="https://vuer.ai/?background=131416,fff&collapseMenu=true&scene=3gAHqGNoaWxkcmVuld4ADahjaGlsZHJlbpKrSGVsbG8gVnVlciHeAAKjdGFnsm1lc2hOb3JtYWxNYXRlcmlhbKNrZXmiNDGjdGFnplRleHQzRKNrZXmnd2VsY29tZaRmb2502UBodHRwczovL3RocmVlanMub3JnL2V4YW1wbGVzL2ZvbnRzL2hlbHZldGlrZXJfYm9sZC50eXBlZmFjZS5qc29upnNtb290aMCqbGluZUhlaWdodACtbGV0dGVyU3BhY2luZ8u%2FmZmZoAAAAKxiZXZlbEVuYWJsZWTDqWJldmVsU2l6Zcs%2FpHrhQAAAAK5iZXZlbFRoaWNrbmVzc8s%2FuZmZoAAAAKRzaXplyz%2F4AAAAAAAApWNvbG9yo3JlZKVzY2FsZcs%2FwzMzQAAAAN4ABqhjaGlsZHJlbpGqRml4ZWQgVGV4dKN0YWekVGV4dKNrZXmqZml4ZWQtdGV4dKVjb2xvcqVncmVlbqhmb250U2l6Zcs%2FuZmZoAAAAKhwb3NpdGlvbpMAyz%2FTMzNAAAAA%2F94AB6hjaGlsZHJlbpHeAAeoY2hpbGRyZW6RrkJpbGxib2FyZCBUZXh0o3RhZ6RUZXh0o2tlea5iaWxsYm9hcmQtdGV4dKVjb2xvcqNyZWSoZm9udFNpemXLP7mZmaAAAAClc2NhbGXLP%2BAAAAAAAACocG9zaXRpb26Tyz%2FTMzNAAAAAyz%2FpmZmgAAAAAKN0YWepQmlsbGJvYXJko2tleaI0MqZmb2xsb3fDpWxvY2tYwqVsb2NrWcKlbG9ja1rC3gAEqGNoaWxkcmVukKN0YWesQW1iaWVudExpZ2h0o2tlea1hbWJpZW50X2xpZ2h0qWludGVuc2l0eQLeAAWoY2hpbGRyZW6Qo3RhZ7BEaXJlY3Rpb25hbExpZ2h0o2tlebFkaXJlY3Rpb25hbF9saWdodKlpbnRlbnNpdHkBqHBvc2l0aW9ukwECAqN0YWelU2NlbmWja2V5ojQ1onVwkwABAKtyYXdDaGlsZHJlbpLeAASoY2hpbGRyZW6Qo3RhZ6xBbWJpZW50TGlnaHSja2V5tWRlZmF1bHRfYW1iaWVudF9saWdodKlpbnRlbnNpdHnLP%2BAAAAAAAADeAAWoY2hpbGRyZW6Qo3RhZ7BEaXJlY3Rpb25hbExpZ2h0o2tleblkZWZhdWx0X2RpcmVjdGlvbmFsX2xpZ2h0qWludGVuc2l0eQGmaGVscGVyw6xodG1sQ2hpbGRyZW6QqmJnQ2hpbGRyZW6T3gADqGNoaWxkcmVukKN0YWeqR3JhYlJlbmRlcqNrZXmnREVGQVVMVN4AA6hjaGlsZHJlbpCjdGFnr1BvaW50ZXJDb250cm9sc6NrZXmiNDPeAAOoY2hpbGRyZW6Qo3RhZ6RHcmlko2tleaI0NA%3D%3D" width="100%" height="400px" frameborder="0"></iframe>
+
 """
 
 with doc, doc.skip if MAKE_DOCS else nullcontext():
@@ -19,57 +23,48 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
     from vuer import Vuer
     from vuer.schemas import (
         Text3D,
-        Center,
         DefaultScene,
-        Group,
-        Box,
         AmbientLight,
         DirectionalLight,
+        Text,
+        Billboard,
+        MeshNormalMaterial,
     )
 
     app = Vuer()
+
 
     @app.spawn(start=True)
     async def show_3d_text(session):
         # Create a scene with some basic elements
         session.set @ DefaultScene(
-            # Basic 3D text example
-            Center(
-                Text3D(
-                    "Hello Vuer!",
-                    font="https://threejs.org/examples/fonts/helvetiker_regular.typeface.json",
-                    smooth=1,
-                    position=[0, 1, 0],
-                    color="blue",
-                    scale=0.2,
-                ),
-                key="centered-text",
-            ),
             # Customized 3D text with different parameters
-            Group(
-                Text3D(
-                    "Custom Text",
-                    font="https://threejs.org/examples/fonts/helvetiker_bold.typeface.json",
-                    smooth=0.5,
-                    lineHeight=0.5,
-                    letterSpacing=-0.025,
-                    position=[0, 0, 0],
-                    color="red",
-                    scale=0.15,
-                ),
-                position=[0, -0.5, 0],
-                key="custom-text",
+            Text3D(
+                "Hello Vuer!",
+                MeshNormalMaterial(),
+                font="https://threejs.org/examples/fonts/helvetiker_bold.typeface.json",
+                bevelEnabled=True,
+                bevelSize=0.04,
+                bevelThickness=0.1,
+                size=1.5,
+                letterSpacing=-0.025,
+                color="red",
+                scale=0.15,
+                key="welcome",
             ),
-            # A small platform below the text
-            Box(
-                width=3,
-                height=0.1,
-                depth=1,
-                position=[0, -1, 0],
-                color="#888888",
+            Text('Fixed Text', color='green', fontSize=0.1, position=[0, 0.3, -1], key="fixed-text"),
+            Billboard(
+                Text(
+                    'Billboard Text',
+                    color="red",
+                    fontSize=0.1,
+                    scale=0.5,
+                    position=[0.3, 0.8, 0],
+                    key="billboard-text",
+                )
             ),
             # Add lighting to make the text visible
-            AmbientLight(intensity=0.5, key="ambient_light"),
+            AmbientLight(intensity=2, key="ambient_light"),
             DirectionalLight(intensity=1, position=[1, 2, 2], key="directional_light"),
         )
         await sleep(0.1)
@@ -77,34 +72,77 @@ with doc, doc.skip if MAKE_DOCS else nullcontext():
         # Demo of rotating text
         angle = 0
         while True:
-            angle += 0.1
-            session.update @ Group(rotation=[0, angle, 0], key="custom-text")
-            await sleep(0.05)
+            angle += 0.01
 
+            session.update([
+                Text3D(
+                    "Hello Vuer!",
+                    MeshNormalMaterial(),
+                    font="https://threejs.org/examples/fonts/helvetiker_bold.typeface.json",
+                    bevelEnabled=True,
+                    bevelSize=0.04,
+                    bevelThickness=0.1,
+                    size=1,
+                    letterSpacing=-0.025,
+                    color="red",
+                    scale=0.1,
+                    key="welcome",
+                    rotation=[0, angle, 0]
+                ),
+                Text('Angle: ' + f'{angle:.2f}', key="fixed-text"),
+            ]),
+            await sleep(0.032)
 
 doc @ """
-## Text3D Component
+## Components Overview
 
-The Text3D component renders 3D text using ThreeJS's TextGeometry. It requires fonts in JSON format
-that can be generated through typeface.json, either as a path to a JSON file or a JSON object.
+### Text3D Component
 
-### Parameters
+The Text3D component renders 3D text using ThreeJS's TextGeometry. It requires fonts in JSON format that can be generated through typeface.json, either as a path to a JSON file or a JSON object.
 
+**Parameters:**
 - **font**: Font URL or JSON object with font data
 - **smooth**: Merges vertices with a tolerance and calls computeVertexNormals
 - **lineHeight**: Line height in threejs units (default: 0)
 - **letterSpacing**: Letter spacing factor (default: 1)
+- Standard Three.js parameters: color, position, rotation, scale, etc.
 
-You can align the text using the Center component as shown in the example.
+You can align the text using the Center component as shown in the example, or combine with Group for animation.
+
+### Text Component
+
+The Text component displays 2D text, suitable for UI labels, annotations, or overlay information.
+
+**Parameters:**
+- **text**: The string to display
+- **color**: Text color
+- **fontSize**: Font size
+- **position**: Position in the scene
+
+### Billboard Component
+
+The Billboard component wraps any content and ensures it always faces the camera. This is useful for floating labels, tooltips, or any UI element that should remain readable regardless of camera orientation.
+
+**Parameters:**
+- **children**: Content to display (e.g., Text)
+- **position**: Position in the scene
+
+#### Example Usage
+
+- `Text('some text')`: Displays 2D text
+- `Billboard(Text('Face', color="blue"))`: Displays a blue label that always faces the camera
 
 ### Tips
 
-- If you face display issues, try checking "Reverse font direction" in the typeface tool.
-- Combine with other components like Group to control positioning and animations.
-- Use standard Three.js parameters like color, position, rotation, and scale to customize appearance.
+- If you face display issues with Text3D, try checking "Reverse font direction" in the typeface tool.
+- Combine Text, Text3D, and Billboard with Group or Center for flexible layout and animation.
+- Use Text for 2D labels, Text3D for 3D scene text, and Billboard for always-facing labels.
 
 ## Additional Resources
 
+- [drei Text3D Documentation](https://drei.docs.pmnd.rs/abstractions/text3d)
+- [drei Text Documentation](https://drei.docs.pmnd.rs/abstractions/text)
+- [drei Billboard Documentation](https://drei.docs.pmnd.rs/abstractions/billboard)
 - [Three.js Text Geometry](https://threejs.org/docs/#api/en/geometries/TextGeometry)
 - [Font creation tools](https://gero3.github.io/facetype.js/)
 """

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,6 +121,7 @@ For a comprehensive list of data types, please refer to the [API documentation o
    Hand Tracking <examples/19_hand_tracking.md>
    Quest 3 Controllers <examples/20_motion_controllers.md>
    3D Movie <examples/21_3D_movie.md>
+   2D/3D Text <examples/22_3d_text.md>
    Raycasted 3D Pointer <examples/21_pointer_example>
    Mujoco Interactive Simulator <examples/24_mujoco_interactive_simulator>
    

--- a/vuer/schemas/__init__.py
+++ b/vuer/schemas/__init__.py
@@ -2,4 +2,5 @@ from .html_components import *
 from .scene_components import *
 from .drei_components import *
 from .physics_components import *
+from .material_components import *
 from .vuer_components import *

--- a/vuer/schemas/html_components.py
+++ b/vuer/schemas/html_components.py
@@ -6,6 +6,7 @@ from vuer.serdes import IMAGE_FORMATS
 
 element_count = 0
 
+_UNSET = object()
 
 class Element:
     """
@@ -23,8 +24,10 @@ class Element:
             key = str(element_count)
             element_count += 1
 
-        self.__dict__.update(tag=self.tag, key=key, **kwargs)
-        self.__post_init__(**{k: v for k, v in kwargs.items() if k.startswith("_")})
+        clean_kwargs = {k: v for k, v in kwargs.items() if v is not _UNSET}
+
+        self.__dict__.update(tag=self.tag, key=key, **clean_kwargs)
+        self.__post_init__(**{k: v for k, v in clean_kwargs.items() if k.startswith("_")})
 
     def serialize(self):
         """
@@ -44,7 +47,6 @@ class Element:
                 output[k] = v
 
         return output
-
 
 class BlockElement(Element):
     def __init__(self, *children, **kwargs):

--- a/vuer/schemas/material_components.py
+++ b/vuer/schemas/material_components.py
@@ -1,0 +1,127 @@
+from .html_components import Element
+
+
+class LineBasicMaterial(Element):
+    tag = "lineBasicMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class LineDashedMaterial(Element):
+    tag = "lineDashedMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class Material(Element):
+    tag = "material"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshBasicMaterial(Element):
+    tag = "meshBasicMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshDepthMaterial(Element):
+    tag = "meshDepthMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshDistanceMaterial(Element):
+    tag = "meshDistanceMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshLambertMaterial(Element):
+    tag = "meshLambertMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshMatcapMaterial(Element):
+    tag = "meshMatcapMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshNormalMaterial(Element):
+    tag = "meshNormalMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshPhongMaterial(Element):
+    tag = "meshPhongMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshPhysicalMaterial(Element):
+    tag = "meshPhysicalMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshStandardMaterial(Element):
+    tag = "meshStandardMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class MeshToonMaterial(Element):
+    tag = "meshToonMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class PointsMaterial(Element):
+    tag = "pointsMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class RawShaderMaterial(Element):
+    tag = "rawShaderMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ShaderMaterial(Element):
+    tag = "shaderMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class ShadowMaterial(Element):
+    tag = "shadowMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class SpriteMaterial(Element):
+    tag = "spriteMaterial"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/vuer/schemas/scene_components.py
+++ b/vuer/schemas/scene_components.py
@@ -1,9 +1,9 @@
-from typing import List, Literal
+from typing import List, Literal, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
 
-from .html_components import BlockElement, Element, Image
+from .html_components import BlockElement, Element, Image, _UNSET
 
 
 class SceneElement(BlockElement):
@@ -995,6 +995,186 @@ class Center(SceneElement):
 
     tag = "Center"
 
+class Billboard(SceneElement):
+    """
+    Renders its children as a billboard that always faces the camera.
+
+    :param follow: Whether the billboard should follow the camera position (default: True)
+    :type follow: bool, optional
+    :param lockX: Lock rotation on the X axis (default: False)
+    :type lockX: bool, optional
+    :param lockY: Lock rotation on the Y axis (default: False)
+    :type lockY: bool, optional
+    :param lockZ: Lock rotation on the Z axis (default: False)
+    :type lockZ: bool, optional
+
+    Example Usage::
+
+        Billboard(
+            follow=True,
+            lockX=False,
+            lockY=True,
+            children=[mesh]
+        )
+    """
+    tag = "Billboard"
+
+    def __init__(
+        self,
+        *children,
+        follow: bool = True,
+        lockX: bool = False,
+        lockY: bool = False,
+        lockZ: bool = False,
+        **kwargs
+    ):
+        super().__init__(
+            *children,
+            follow=follow,
+            lockX=lockX,
+            lockY=lockY,
+            lockZ=lockZ,
+            **kwargs
+        )
+
+class Text(SceneElement):
+    """
+    Renders 2D text in the scene with extensive styling and layout options.
+
+    :param children: The text content to render.
+    :type children: str
+    :param characters: Restrict the set of characters to use for glyph generation.
+    :type characters: str, optional
+    :param color: Text color.
+    :type color: str, optional
+    :param fontSize: Font size in world units.
+    :type fontSize: float, optional
+    :param fontWeight: Font weight (number or string, e.g. 'bold').
+    :type fontWeight: int or str, optional
+    :param fontStyle: Font style, either 'italic' or 'normal'.
+    :type fontStyle: str, optional
+    :param maxWidth: Maximum width of the text block before wrapping.
+    :type maxWidth: float, optional
+    :param lineHeight: Line height as a multiple of fontSize.
+    :type lineHeight: float, optional
+    :param letterSpacing: Additional spacing between letters.
+    :type letterSpacing: float, optional
+    :param textAlign: Text alignment: 'left', 'right', 'center', or 'justify'.
+    :type textAlign: str, optional
+    :param font: Font URL or name.
+    :type font: str, optional
+    :param anchorX: Horizontal anchor: number or 'left', 'center', 'right'.
+    :type anchorX: float or str, optional
+    :param anchorY: Vertical anchor: number or 'top', 'top-baseline', 'middle', 'bottom-baseline', 'bottom'.
+    :type anchorY: float or str, optional
+    :param clipRect: Rectangle [minX, minY, maxX, maxY] to clip text rendering.
+    :type clipRect: list[float], optional
+    :param depthOffset: Offset in Z to avoid z-fighting.
+    :type depthOffset: float, optional
+    :param direction: Text direction: 'auto', 'ltr', or 'rtl'.
+    :type direction: str, optional
+    :param overflowWrap: Wrapping behavior: 'normal' or 'break-word'.
+    :type overflowWrap: str, optional
+    :param whiteSpace: White space handling: 'normal', 'overflowWrap', or 'nowrap'.
+    :type whiteSpace: str, optional
+    :param outlineWidth: Outline width (number or string, e.g. '2px').
+    :type outlineWidth: float or str, optional
+    :param outlineOffsetX: Outline X offset (number or string).
+    :type outlineOffsetX: float or str, optional
+    :param outlineOffsetY: Outline Y offset (number or string).
+    :type outlineOffsetY: float or str, optional
+    :param outlineBlur: Outline blur radius (number or string).
+    :type outlineBlur: float or str, optional
+    :param outlineColor: Outline color.
+    :type outlineColor: str, optional
+    :param outlineOpacity: Outline opacity (0-1).
+    :type outlineOpacity: float, optional
+    :param strokeWidth: Stroke width (number or string).
+    :type strokeWidth: float or str, optional
+    :param strokeColor: Stroke color.
+    :type strokeColor: str, optional
+    :param strokeOpacity: Stroke opacity (0-1).
+    :type strokeOpacity: float, optional
+    :param fillOpacity: Fill opacity (0-1).
+    :type fillOpacity: float, optional
+    :param sdfGlyphSize: SDF glyph size for rendering quality.
+    :type sdfGlyphSize: int, optional
+    :param debugSDF: Show SDF debug overlay.
+    :type debugSDF: bool, optional
+    :param glyphGeometryDetail: Level of detail for glyph geometry.
+    :type glyphGeometryDetail: int, optional
+    """
+    tag = "Text"
+
+    def __init__(
+        self,
+        *children,
+        characters: Union[str, None, object] = _UNSET,
+        color: Union[str, None, object] = _UNSET,
+        fontSize: Union[float, None, object] = _UNSET,
+        fontWeight: Union[int, str, None, object] = _UNSET,
+        fontStyle: Union[str, None, object] = _UNSET,
+        maxWidth: Union[float, None, object] = _UNSET,
+        lineHeight: Union[float, None, object] = _UNSET,
+        letterSpacing: Union[float, None, object] = _UNSET,
+        textAlign: Union[str, None, object] = _UNSET,
+        font: Union[str, None, object] = _UNSET,
+        anchorX: Union[float, str, None, object] = _UNSET,
+        anchorY: Union[float, str, None, object] = _UNSET,
+        clipRect: Union[list, None, object] = _UNSET,
+        depthOffset: Union[float, None, object] = _UNSET,
+        direction: Union[str, None, object] = _UNSET,
+        overflowWrap: Union[str, None, object] = _UNSET,
+        whiteSpace: Union[str, None, object] = _UNSET,
+        outlineWidth: Union[float, str, None, object] = _UNSET,
+        outlineOffsetX: Union[float, str, None, object] = _UNSET,
+        outlineOffsetY: Union[float, str, None, object] = _UNSET,
+        outlineBlur: Union[float, str, None, object] = _UNSET,
+        outlineColor: Union[str, None, object] = _UNSET,
+        outlineOpacity: Union[float, None, object] = _UNSET,
+        strokeWidth: Union[float, str, None, object] = _UNSET,
+        strokeColor: Union[str, None, object] = _UNSET,
+        strokeOpacity: Union[float, None, object] = _UNSET,
+        fillOpacity: Union[float, None, object] = _UNSET,
+        sdfGlyphSize: Union[int, None, object] = _UNSET,
+        debugSDF: Union[bool, None, object] = _UNSET,
+        glyphGeometryDetail: Union[int, None, object] = _UNSET,
+        **kwargs
+    ):
+        super().__init__(
+            *children,
+            characters=characters,
+            color=color,
+            fontSize=fontSize,
+            fontWeight=fontWeight,
+            fontStyle=fontStyle,
+            maxWidth=maxWidth,
+            lineHeight=lineHeight,
+            letterSpacing=letterSpacing,
+            textAlign=textAlign,
+            font=font,
+            anchorX=anchorX,
+            anchorY=anchorY,
+            clipRect=clipRect,
+            depthOffset=depthOffset,
+            direction=direction,
+            overflowWrap=overflowWrap,
+            whiteSpace=whiteSpace,
+            outlineWidth=outlineWidth,
+            outlineOffsetX=outlineOffsetX,
+            outlineOffsetY=outlineOffsetY,
+            outlineBlur=outlineBlur,
+            outlineColor=outlineColor,
+            outlineOpacity=outlineOpacity,
+            strokeWidth=strokeWidth,
+            strokeColor=strokeColor,
+            strokeOpacity=strokeOpacity,
+            fillOpacity=fillOpacity,
+            sdfGlyphSize=sdfGlyphSize,
+            debugSDF=debugSDF,
+            glyphGeometryDetail=glyphGeometryDetail,
+            **kwargs
+        )
 
 class Text3D(SceneElement):
     """Renders 3D text using ThreeJS's TextGeometry.


### PR DESCRIPTION
This pull request introduces a new 3D/2D Text example.

<img width="1710" height="1030" alt="22_3d_text" src="https://github.com/user-attachments/assets/6d10ddff-4f28-40f5-b1a8-20305b5ec63b" />


https://github.com/user-attachments/assets/4f3518d4-ee2c-4dbf-80bc-2d72e3a5bf8c



[==> live preview <==](https://vuer.ai/?background=131416,fff&collapseMenu=true&scene=3gAHqGNoaWxkcmVuld4ADahjaGlsZHJlbpKrSGVsbG8gVnVlciHeAAKjdGFnsm1lc2hOb3JtYWxNYXRlcmlhbKNrZXmiNDGjdGFnplRleHQzRKNrZXmnd2VsY29tZaRmb2502UBodHRwczovL3RocmVlanMub3JnL2V4YW1wbGVzL2ZvbnRzL2hlbHZldGlrZXJfYm9sZC50eXBlZmFjZS5qc29upnNtb290aMCqbGluZUhlaWdodACtbGV0dGVyU3BhY2luZ8u%2FmZmZoAAAAKxiZXZlbEVuYWJsZWTDqWJldmVsU2l6Zcs%2FpHrhQAAAAK5iZXZlbFRoaWNrbmVzc8s%2FuZmZoAAAAKRzaXplyz%2F4AAAAAAAApWNvbG9yo3JlZKVzY2FsZcs%2FwzMzQAAAAN4ABqhjaGlsZHJlbpGqRml4ZWQgVGV4dKN0YWekVGV4dKNrZXmqZml4ZWQtdGV4dKVjb2xvcqVncmVlbqhmb250U2l6Zcs%2FuZmZoAAAAKhwb3NpdGlvbpMAyz%2FTMzNAAAAA%2F94AB6hjaGlsZHJlbpHeAAeoY2hpbGRyZW6RrkJpbGxib2FyZCBUZXh0o3RhZ6RUZXh0o2tlea5iaWxsYm9hcmQtdGV4dKVjb2xvcqNyZWSoZm9udFNpemXLP7mZmaAAAAClc2NhbGXLP%2BAAAAAAAACocG9zaXRpb26Tyz%2FTMzNAAAAAyz%2FpmZmgAAAAAKN0YWepQmlsbGJvYXJko2tleaI0MqZmb2xsb3fDpWxvY2tYwqVsb2NrWcKlbG9ja1rC3gAEqGNoaWxkcmVukKN0YWesQW1iaWVudExpZ2h0o2tlea1hbWJpZW50X2xpZ2h0qWludGVuc2l0eQLeAAWoY2hpbGRyZW6Qo3RhZ7BEaXJlY3Rpb25hbExpZ2h0o2tlebFkaXJlY3Rpb25hbF9saWdodKlpbnRlbnNpdHkBqHBvc2l0aW9ukwECAqN0YWelU2NlbmWja2V5ojQ1onVwkwABAKtyYXdDaGlsZHJlbpLeAASoY2hpbGRyZW6Qo3RhZ6xBbWJpZW50TGlnaHSja2V5tWRlZmF1bHRfYW1iaWVudF9saWdodKlpbnRlbnNpdHnLP%2BAAAAAAAADeAAWoY2hpbGRyZW6Qo3RhZ7BEaXJlY3Rpb25hbExpZ2h0o2tleblkZWZhdWx0X2RpcmVjdGlvbmFsX2xpZ2h0qWludGVuc2l0eQGmaGVscGVyw6xodG1sQ2hpbGRyZW6QqmJnQ2hpbGRyZW6T3gADqGNoaWxkcmVukKN0YWeqR3JhYlJlbmRlcqNrZXmnREVGQVVMVN4AA6hjaGlsZHJlbpCjdGFnr1BvaW50ZXJDb250cm9sc6NrZXmiNDPeAAOoY2hpbGRyZW6Qo3RhZ6RHcmlko2tleaI0NA%3D%3D)