### PR TITLE
feat: migrate to params-proto v3 native syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "params-proto>=3.0.0rc11",
+    "params-proto>=3.0.0rc14",
     "pillow",
     "msgpack",
     "numpy>=1.21", # because we require numpy.typing.NDArray

--- a/src/vuer/__init__.py
+++ b/src/vuer/__init__.py
@@ -14,4 +14,11 @@ except ImportError:
     Also, we require numpy>=1.21 for numpy.typing.NDArray.
     """)
 
-__all__ = ["Vuer", "VuerSession"]
+
+def entrypoint():
+    """CLI entrypoint for vuer command."""
+    app = Vuer()
+    app.run()
+
+
+__all__ = ["Vuer", "VuerSession", "entrypoint"]

--- a/src/vuer/base.py
+++ b/src/vuer/base.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import aiohttp_cors
 from aiohttp import web
-from params_proto.v2 import Proto
+from params_proto import EnvVar
 
 
 async def default_handler(request, ws):
@@ -70,30 +70,58 @@ async def handle_file_request(request, root, filename=None):
 
 
 class Server:
-    """Base TCP server"""
+    """Base TCP server with HTTP/WebSocket functionality.
 
-    host = Proto(env="HOST", default="localhost")
-    cors = Proto(help="Enable CORS", default="*")
-    port = Proto(env="PORT", default=8012)
+    This class provides the core server infrastructure for Vuer, including:
+    - HTTP route handling with CORS support
+    - WebSocket connection management
+    - SSL/TLS support for secure connections
+    - Static file serving
 
-    cert = Proto(None, dtype=str, help="the path to the SSL certificate")
-    key = Proto(None, dtype=str, help="the path to the SSL key")
-    ca_cert = Proto(None, dtype=str, help="the trusted root CA certificates")
+    Subclasses should call _init_app() in their __post_init__ to initialize
+    the aiohttp application before using server methods.
 
-    WEBSOCKET_MAX_SIZE: int = Proto(
-        2**28,
-        env="WEBSOCKET_MAX_SIZE",
-        help="maximum size for websocket requests.",
-    )
-    REQUEST_MAX_SIZE: int = Proto(
-        2**28,
-        env="REQUEST_MAX_SIZE",
-        help="maximum size for requests.",
-    )
+    Note: This class cannot use @proto.prefix because Vuer inherits from it
+    and also uses @proto.prefix, which causes a metaclass conflict.
 
-    def __post_init__(self):
+    Attributes:
+        host: Server hostname. Set to "0.0.0.0" to accept remote connections.
+        port: Server port number.
+        cors: Comma-separated list of allowed CORS origins. Use "*" for all.
+        cert: Path to SSL certificate file for HTTPS.
+        key: Path to SSL private key file for HTTPS.
+        ca_cert: Path to CA certificate for client certificate verification.
+        WEBSOCKET_MAX_SIZE: Maximum WebSocket message size (default 256MB).
+        REQUEST_MAX_SIZE: Maximum HTTP request size (default 256MB).
+    """
+
+    # Network configuration (can be set via environment variables)
+    host: str = EnvVar("HOST", default="localhost").get()  # Server hostname, use 0.0.0.0 for remote access
+    port: int = EnvVar("PORT", dtype=int, default=8012).get()  # Server port number
+    cors: str = EnvVar("CORS", default="*").get()  # CORS allowed origins, comma-separated
+
+    # SSL/TLS configuration (all None = HTTP mode)
+    cert: str = EnvVar("SSL_CERT", default=None).get()  # Path to SSL certificate file
+    key: str = EnvVar("SSL_KEY", default=None).get()  # Path to SSL private key file
+    ca_cert: str = EnvVar("SSL_CA_CERT", default=None).get()  # Path to CA certificate for client verification
+
+    # Size limits
+    WEBSOCKET_MAX_SIZE: int = EnvVar("WEBSOCKET_MAX_SIZE", dtype=int, default=2**28).get()  # Max WebSocket message size (default 256MB)
+    REQUEST_MAX_SIZE: int = EnvVar("REQUEST_MAX_SIZE", dtype=int, default=2**28).get()  # Max HTTP request size (default 256MB)
+
+    def _init_app(self):
+        """Initialize the aiohttp application and CORS context.
+
+        This must be called before using any server methods. Subclasses
+        should call this in their __post_init__ method.
+
+        Creates:
+            self.app: The aiohttp web.Application instance.
+            self.cors_context: The aiohttp_cors setup for CORS handling.
+        """
+        if hasattr(self, 'app'):
+            return
         self.app = web.Application(client_max_size=self.REQUEST_MAX_SIZE)
-
         default = aiohttp_cors.ResourceOptions(
             allow_credentials=True,
             expose_headers="*",
@@ -101,7 +129,6 @@ class Server:
             allow_methods="*",
         )
         cors_config = {k: default for k in self.cors.split(",")}
-
         self.cors_context = aiohttp_cors.setup(self.app, defaults=cors_config)
 
     def _add_route(


### PR DESCRIPTION
## Summary
- Migrate from params-proto v2 compatibility layer to native v3 syntax using `@proto.prefix` decorator
- Update params-proto to `>=3.0.0rc14` which fixes static method wrapper issues and adds `__post_init__` support
- Add `EnvVar` support for environment variable configuration in base `Server` class
- Add comprehensive docstrings and help comments for CLI support

## Changes
- **pyproject.toml**: Update params-proto dependency to `>=3.0.0rc14`
- **base.py**: Use `EnvVar(...).get()` for env vars, add `_init_app()` for lazy initialization, add docstrings
- **server.py**: Change from `PrefixProto` inheritance to `@proto.prefix` decorator, type annotations with help comments
- **__init__.py**: Add `entrypoint()` function for CLI

## Test plan
- [x] Verify `uv sync` completes successfully
- [x] Test `from vuer import Vuer; app = Vuer()` works
- [x] Verify settings are accessible (host, port, cors)
- [ ] Test with environment variables (HOST, PORT, CORS)

cc @Yanbing-Han 

🤖 Generated with [Claude Code](https://claude.com/claude-code)