### PR TITLE
feat: use VUER_ prefix for SSL env vars

### DIFF
--- a/src/vuer/base.py
+++ b/src/vuer/base.py
@@ -99,9 +99,9 @@ class Server:
     port: int = EnvVar @ "PORT" | 8012
     cors: str = EnvVar @ "CORS" | "*"
 
-    cert: str = EnvVar @ "SSL_CERT" | None
-    key: str = EnvVar @ "SSL_KEY" | None
-    ca_cert: str = EnvVar @ "SSL_CA_CERT" | None
+    cert: str = EnvVar @ "VUER_SSL_CERT" | None
+    key: str = EnvVar @ "VUER_SSL_KEY" | None
+    ca_cert: str = EnvVar @ "VUER_SSL_CA_CERT" | None
 
     WEBSOCKET_MAX_SIZE: int = EnvVar @ "WEBSOCKET_MAX_SIZE" | 2**28
     REQUEST_MAX_SIZE: int = EnvVar @ "REQUEST_MAX_SIZE" | 2**28


### PR DESCRIPTION
## Summary

Add `VUER_` prefix to SSL-related environment variables to avoid conflicts with other applications.

### Changes

| Before | After |
|--------|-------|
| `SSL_CERT` | `VUER_SSL_CERT` |
| `SSL_KEY` | `VUER_SSL_KEY` |
| `SSL_CA_CERT` | `VUER_SSL_CA_CERT` |

### Usage

```bash
VUER_SSL_CERT=/path/to/cert.pem VUER_SSL_KEY=/path/to/key.pem python app.py
```