### PR TITLE
feat: add vuer skills for code assistance

### DIFF
--- a/skills/vuer.md
+++ b/skills/vuer.md
@@ -1,0 +1,64 @@
+---
+description: Vuer - real-time 3D visualization toolkit for robotics and AI
+topics: [vuer, 3d, visualization, robotics, webxr, python]
+---
+
+# Vuer
+
+Vuer is a lightweight, event-driven, declarative visualization toolkit for GenAI and robotics. It provides real-time 3D visualization in the browser with VR/AR support.
+
+## Architecture
+
+```
+Python Backend (async/aiohttp) <--WebSocket--> Browser Client (Three.js)
+```
+
+## Installation
+
+```bash
+pip install 'vuer[all]'
+```
+
+## Basic Usage
+
+```python
+from vuer import Vuer, VuerSession
+from vuer.schemas import DefaultScene, Box, Sphere
+
+app = Vuer()
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Box(key="box", args=[0.2, 0.2, 0.2], position=[0, 0, 0]),
+        Sphere(key="sphere", args=[0.1], position=[0.5, 0, 0]),
+    )
+    await session.forever()
+```
+
+View at https://vuer.ai (connects to ws://localhost:8012 by default).
+
+## Core Concepts
+
+- **Vuer**: Server class that manages WebSocket connections
+- **VuerSession**: Client session with scene manipulation APIs
+- **Components**: Declarative 3D elements (Box, Sphere, TriMesh, Urdf, etc.)
+- **Events**: Bidirectional communication via `@app.add_handler()`
+
+## Session APIs
+
+| API | Purpose |
+|-----|---------|
+| `session.set @ Scene(...)` | Initialize root scene (once) |
+| `session.upsert @ Element(...)` | Update or insert element |
+| `session.update @ Element(...)` | Update existing only |
+| `session.add @ Element(...)` | Add new element |
+| `session.remove @ "key"` | Remove by key |
+
+## Related Skills
+
+- [vuer/server](vuer/server.md) - Server configuration and lifecycle
+- [vuer/components](vuer/components.md) - Component reference
+- [vuer/events](vuer/events.md) - Event system and handlers
+- [vuer/examples](vuer/examples.md) - Common patterns
+- [vuer/xr](vuer/xr.md) - VR/AR features

--- a/skills/vuer/components.md
+++ b/skills/vuer/components.md
@@ -1,0 +1,217 @@
+---
+description: Vuer component reference - 3D primitives, models, cameras, and more
+topics: [vuer, components, 3d, primitives, models]
+---
+
+# Vuer Components
+
+All components are imported from `vuer.schemas`:
+
+```python
+from vuer.schemas import Box, Sphere, TriMesh, Urdf, PointCloud, ...
+```
+
+## Common Properties
+
+All components accept:
+- `key` (str): Unique identifier (required for updates)
+- `position` (tuple): [x, y, z] position
+- `rotation` (tuple): [x, y, z] Euler rotation in radians
+- `scale` (tuple): [x, y, z] scale factors
+- `matrix` (list): 4x4 transformation matrix (16 floats)
+- `children` (list): Child components
+
+## Primitives
+
+### Box
+```python
+Box(key="box", args=[1, 1, 1], position=[0, 0, 0], color="red")
+# args: [width, height, depth]
+```
+
+### Sphere
+```python
+Sphere(key="sphere", args=[0.5, 32, 16], position=[0, 1, 0])
+# args: [radius, widthSegments, heightSegments]
+```
+
+### Cylinder
+```python
+Cylinder(key="cyl", args=[0.5, 0.5, 2, 32])
+# args: [radiusTop, radiusBottom, height, radialSegments]
+```
+
+### Capsule
+```python
+Capsule(key="cap", args=[0.2, 1, 4, 8])
+# args: [radius, height, capSegments, radialSegments]
+```
+
+### Cone, Plane, Ring, Torus, TorusKnot
+```python
+Cone(key="cone", args=[1, 2, 8])
+Plane(key="plane", args=[2, 2])
+Ring(key="ring", args=[0.5, 1, 32])
+Torus(key="torus", args=[1, 0.4, 16, 100])
+```
+
+## Custom Geometry
+
+### TriMesh
+```python
+import numpy as np
+from vuer.schemas import TriMesh
+
+vertices = np.array([[0,0,0], [1,0,0], [0.5,1,0]], dtype=np.float16)
+faces = np.array([[0, 1, 2]], dtype=np.uint32)
+colors = np.array([[255,0,0], [0,255,0], [0,0,255]], dtype=np.uint8)
+
+TriMesh(key="mesh", vertices=vertices, faces=faces, colors=colors)
+```
+
+### PointCloud
+```python
+PointCloud(
+    key="pcd",
+    vertices=np.random.rand(1000, 3).astype(np.float16),
+    colors=np.random.rand(1000, 3).astype(np.uint8) * 255,
+    size=0.01
+)
+```
+
+## Model Loaders
+
+### URDF (Robots)
+```python
+Urdf(
+    key="robot",
+    src="/static/robot.urdf",
+    jointValues={"joint1": 0.5, "joint2": -0.3},
+    position=[0, 0, 0]
+)
+```
+
+### GLB/GLTF
+```python
+Glb(key="model", src="/static/model.glb", scale=0.1)
+```
+
+### OBJ, PLY, STL, FBX, DAE
+```python
+Obj(key="obj", src="/static/model.obj")
+Ply(key="ply", src="/static/model.ply")
+Stl(key="stl", src="/static/model.stl")
+Fbx(key="fbx", src="/static/model.fbx")
+Dae(key="dae", src="/static/model.dae")
+```
+
+## Gaussian Splatting
+
+```python
+Splat(key="splat", src="/static/scene.splat")
+LumaSplats(key="luma", src="https://lumalabs.ai/capture/...")
+```
+
+## Cameras
+
+```python
+PerspectiveCamera(
+    key="cam",
+    fov=75,
+    position=[5, 5, 5],
+    makeDefault=True
+)
+
+OrthographicCamera(key="ortho", zoom=1)
+```
+
+### Camera Frustum Visualization
+```python
+Frustum(
+    key="frustum",
+    fov=60,
+    aspect=1.6,
+    near=0.1,
+    far=10,
+    showFrustum=True,
+    showImagePlane=True
+)
+```
+
+## Lighting
+
+```python
+AmbientLight(key="ambient", intensity=0.5)
+DirectionalLight(key="dir", intensity=1, position=[5, 5, 5])
+PointLight(key="point", intensity=1, position=[0, 3, 0])
+SpotLight(key="spot", intensity=1, angle=0.5, position=[0, 5, 0])
+```
+
+## Text
+
+```python
+Text(key="label", text="Hello", position=[0, 2, 0], fontSize=0.5)
+Text3D(key="3d-text", text="3D", height=0.2, bevelEnabled=True)
+Billboard(key="billboard", text="Always faces camera")
+```
+
+## Lines
+
+```python
+Line(key="line", points=[[0,0,0], [1,1,1], [2,0,0]], color="blue")
+CatmullRomLine(key="curve", points=[...], tension=0.5)
+CubicBezierLine(key="bezier", start=[0,0,0], end=[1,1,0], ...)
+```
+
+## Interaction
+
+### Movable (Drag & Drop)
+```python
+Movable(
+    key="movable-box",
+    children=[Box(key="box")],
+    position=[0, 0, 0]
+)
+```
+
+### Gripper
+```python
+Gripper(
+    key="gripper",
+    position=[0, 0, 0],
+    pinchWidth=0.04
+)
+```
+
+## Organization
+
+### Group
+```python
+group(
+    key="my-group",
+    children=[
+        Box(key="box1"),
+        Sphere(key="sphere1"),
+    ],
+    position=[0, 0, 0]
+)
+```
+
+### Scene
+```python
+Scene(
+    children=[...],
+    bgChildren=[Grid(), CoordsMarker()],
+    rawChildren=[AmbientLight()],
+)
+
+DefaultScene(...)  # Includes default lighting and controls
+```
+
+## Helpers
+
+```python
+Grid(key="grid", args=[10, 10])
+CoordsMarker(key="coords", size=1)
+Arrow(key="arrow", direction=[0, 1, 0], length=1)
+```

--- a/skills/vuer/events.md
+++ b/skills/vuer/events.md
@@ -1,0 +1,178 @@
+---
+description: Vuer event system - client/server communication and session APIs
+topics: [vuer, events, websocket, session, api]
+---
+
+# Vuer Events
+
+Vuer uses an event-driven architecture for real-time bidirectional communication.
+
+## Session APIs
+
+### session.set - Initialize Scene
+
+Sets the root scene. Use once at session start.
+
+```python
+from vuer.schemas import DefaultScene, Box
+
+session.set @ DefaultScene(
+    Box(key="box", args=[1, 1, 1]),
+)
+```
+
+### session.upsert - Update or Insert
+
+Most common API. Updates if exists, creates if not.
+
+```python
+# Single element
+session.upsert @ Box(key="box", position=[1, 0, 0])
+
+# Multiple elements
+session.upsert @ [
+    Box(key="box1", position=[0, 0, 0]),
+    Sphere(key="sphere1", position=[1, 0, 0]),
+]
+
+# To specific parent
+session.upsert(Box(key="child"), to="parent-key")
+```
+
+### session.update - Update Only
+
+Updates existing elements. NOOP if element doesn't exist.
+
+```python
+session.update @ Box(key="box", color="blue")  # Only updates if "box" exists
+```
+
+### session.add - Add New
+
+Adds new elements. Use when certain element doesn't exist.
+
+```python
+session.add @ Box(key="new-box")
+session.add(Sphere(key="child"), to="parent-key")
+```
+
+### session.remove - Remove Elements
+
+```python
+session.remove @ "box-key"
+session.remove @ ["key1", "key2", "key3"]
+```
+
+## Event Handlers
+
+Register handlers for client events:
+
+```python
+@app.add_handler("CAMERA_MOVE")
+async def on_camera(event: ClientEvent, session: VuerSession):
+    print(f"Camera position: {event.value}")
+```
+
+### Common Event Types
+
+| Event Type | Description | event.value |
+|------------|-------------|-------------|
+| `CAMERA_MOVE` | Camera moved | position, rotation, matrix |
+| `HAND_MOVE` | Hand tracking | hand data with joints |
+| `OBJECT_MOVE` | Movable object moved | position, rotation |
+| `CLICK` | Element clicked | element key, position |
+| `UPLOAD` | File uploaded | PIL.Image |
+
+### Handler with Cleanup
+
+```python
+cleanup = app.add_handler("CAMERA_MOVE", handler_fn)
+# Later, remove the handler
+cleanup()
+```
+
+### One-time Handler
+
+```python
+app.add_handler("CAMERA_MOVE", handler_fn, once=True)
+```
+
+## RPC Methods
+
+### grab_render - Capture Frame
+
+```python
+render = await session.grab_render(quality=0.9)
+image = render.value  # PIL.Image or base64 data
+```
+
+### get_webxr_mesh - AR Mesh Data
+
+```python
+mesh_data = await session.get_webxr_mesh(key="webxr-mesh")
+for mesh in mesh_data.value['meshes']:
+    vertices = mesh['vertices']
+    indices = mesh['indices']
+    label = mesh.get('semanticLabel')
+```
+
+## Background Tasks
+
+```python
+async def background_task():
+    while True:
+        await asyncio.sleep(1)
+        print("tick")
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    task = session.spawn_task(background_task())
+
+    session.set @ DefaultScene()
+    await session.forever()
+
+    # To cancel:
+    task.cancel()
+```
+
+## Server Events (Internal)
+
+These are sent automatically by session APIs:
+
+| Event | Triggered By |
+|-------|--------------|
+| `Set` | `session.set @ Scene(...)` |
+| `Update` | `session.update @ Element(...)` |
+| `Add` | `session.add @ Element(...)` |
+| `Upsert` | `session.upsert @ Element(...)` |
+| `Remove` | `session.remove @ "key"` |
+| `Frame` | `yield Frame(...)` in bind handler |
+
+## Streaming Pattern
+
+For high-frequency updates:
+
+```python
+@app.bind(start=True)
+async def streaming(session: VuerSession):
+    session.set @ DefaultScene()
+
+    t = 0
+    while True:
+        t += 0.016
+        yield Frame(
+            Update(Box(key="box", position=[np.sin(t), 0, 0])),
+            frame_rate=60
+        )
+```
+
+## Error Handling
+
+```python
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    try:
+        render = await session.grab_render(ttl=2.0)
+    except asyncio.TimeoutError:
+        print("Render request timed out")
+```

--- a/skills/vuer/examples.md
+++ b/skills/vuer/examples.md
@@ -1,0 +1,267 @@
+---
+description: Common Vuer patterns and examples
+topics: [vuer, examples, patterns, robotics, visualization]
+---
+
+# Vuer Examples
+
+## Basic Scene
+
+```python
+from vuer import Vuer, VuerSession
+from vuer.schemas import DefaultScene, Box, Sphere, AmbientLight
+
+app = Vuer()
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Box(key="box", args=[1, 1, 1], position=[-1, 0.5, 0], color="red"),
+        Sphere(key="sphere", args=[0.5], position=[1, 0.5, 0], color="blue"),
+    )
+    await session.forever()
+```
+
+## Animation Loop
+
+```python
+import asyncio
+import numpy as np
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene()
+
+    t = 0
+    while True:
+        t += 0.05
+        session.upsert @ Box(
+            key="animated-box",
+            position=[np.sin(t), 0.5, np.cos(t)],
+            rotation=[0, t, 0]
+        )
+        await asyncio.sleep(0.016)  # ~60 FPS
+```
+
+## URDF Robot
+
+```python
+from vuer.schemas import Urdf
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Urdf(
+            key="robot",
+            src="/static/robots/panda.urdf",
+            jointValues={
+                "panda_joint1": 0,
+                "panda_joint2": -0.5,
+                "panda_joint3": 0,
+                "panda_joint4": -2.0,
+                "panda_joint5": 0,
+                "panda_joint6": 1.5,
+                "panda_joint7": 0.7,
+            }
+        )
+    )
+    await session.forever()
+```
+
+## Point Cloud
+
+```python
+import numpy as np
+from vuer.schemas import PointCloud
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    # Generate random point cloud
+    n_points = 10000
+    vertices = np.random.randn(n_points, 3).astype(np.float16) * 2
+    colors = (np.random.rand(n_points, 3) * 255).astype(np.uint8)
+
+    session.set @ DefaultScene(
+        PointCloud(key="pcd", vertices=vertices, colors=colors, size=0.02)
+    )
+    await session.forever()
+```
+
+## Camera Control
+
+```python
+from vuer.schemas import PerspectiveCamera
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        PerspectiveCamera(
+            key="main-cam",
+            fov=75,
+            position=[5, 3, 5],
+            makeDefault=True
+        ),
+        Box(key="box"),
+    )
+    await session.forever()
+
+# Handle camera events
+@app.add_handler("CAMERA_MOVE")
+async def on_camera(event, session):
+    print(f"Camera: {event.value}")
+```
+
+## Interactive Movable
+
+```python
+from vuer.schemas import Movable, Box
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Movable(
+            key="movable",
+            children=[Box(key="box", color="green")],
+            position=[0, 0.5, 0]
+        )
+    )
+    await session.forever()
+
+@app.add_handler("OBJECT_MOVE")
+async def on_move(event, session):
+    print(f"Object moved to: {event.value}")
+```
+
+## Dynamic Elements
+
+```python
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene()
+
+    # Add elements dynamically
+    for i in range(10):
+        session.add @ Sphere(
+            key=f"sphere-{i}",
+            args=[0.1],
+            position=[i * 0.3 - 1.5, 0.5, 0]
+        )
+        await asyncio.sleep(0.2)
+
+    # Remove some
+    await asyncio.sleep(1)
+    session.remove @ ["sphere-0", "sphere-1", "sphere-2"]
+
+    await session.forever()
+```
+
+## Batch Updates
+
+```python
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene()
+
+    while True:
+        positions = compute_positions()  # Your logic
+
+        # Efficient batch update
+        session.upsert @ [
+            Box(key=f"box-{i}", position=pos)
+            for i, pos in enumerate(positions)
+        ]
+        await asyncio.sleep(0.016)
+```
+
+## Frame Capture
+
+```python
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(Box(key="box"))
+
+    await asyncio.sleep(1)  # Wait for render
+
+    render = await session.grab_render(quality=0.9)
+    image = render.value  # PIL.Image
+    image.save("screenshot.png")
+
+    await session.forever()
+```
+
+## Multiple Handlers
+
+```python
+@app.add_handler("CAMERA_MOVE")
+async def camera_handler(event, session):
+    # Log camera position
+    pass
+
+@app.add_handler("HAND_MOVE")
+async def hand_handler(event, session):
+    # Process hand tracking
+    pass
+
+@app.add_handler("OBJECT_MOVE")
+async def object_handler(event, session):
+    # React to object movement
+    pass
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Movable(key="movable", children=[Box(key="box")]),
+        Hands(key="hands")  # Enable hand tracking
+    )
+    await session.forever()
+```
+
+## Hierarchical Scene
+
+```python
+from vuer.schemas import group
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        group(
+            key="robot-arm",
+            children=[
+                Box(key="base", args=[0.5, 0.1, 0.5]),
+                group(
+                    key="link1",
+                    position=[0, 0.1, 0],
+                    children=[
+                        Cylinder(key="joint1", args=[0.05, 0.05, 0.3]),
+                        group(
+                            key="link2",
+                            position=[0, 0.3, 0],
+                            children=[
+                                Cylinder(key="joint2", args=[0.05, 0.05, 0.3]),
+                            ]
+                        )
+                    ]
+                )
+            ]
+        )
+    )
+    await session.forever()
+```
+
+## GLB Model
+
+```python
+from vuer.schemas import Glb
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Glb(
+            key="model",
+            src="/static/model.glb",
+            scale=0.5,
+            position=[0, 0, 0]
+        )
+    )
+    await session.forever()
+```

--- a/skills/vuer/server.md
+++ b/skills/vuer/server.md
@@ -1,0 +1,124 @@
+---
+description: Vuer server configuration and lifecycle management
+topics: [vuer, server, websocket, configuration]
+---
+
+# Vuer Server
+
+## Creating the Server
+
+```python
+from vuer import Vuer
+
+app = Vuer(
+    port=8012,              # WebSocket port (default: 8012)
+    static_root=".",        # Static file directory
+    cors="*",               # CORS configuration
+    free_port=False,        # Auto-kill process on port
+    verbose=False,          # Print settings on startup
+)
+```
+
+## Environment Variables
+
+- `VUER_PORT` - Server port
+- `VUER_DOMAIN` - Client domain (default: https://vuer.ai)
+- `VUER_CORS` - CORS allowed origins
+- `VUER_STATIC_ROOT` - Static file root directory
+
+## Decorators
+
+### @app.spawn - Main Handler
+
+```python
+@app.spawn(start=True)  # start=True auto-starts server
+async def main(session: VuerSession):
+    session.set @ DefaultScene()
+    await session.forever()
+```
+
+Deferred start:
+```python
+@app.spawn()  # start=False by default
+async def main(session: VuerSession):
+    ...
+
+# Later
+main.start()
+```
+
+### @app.bind - Generator Handler
+
+For frame-by-frame streaming:
+
+```python
+@app.bind(start=True)
+async def handler(session: VuerSession):
+    session.set @ DefaultScene()
+    while True:
+        event = yield Frame(Update(...), frame_rate=60)
+```
+
+## Event Handlers
+
+```python
+@app.add_handler("CAMERA_MOVE")
+async def on_camera(event: ClientEvent, session: VuerSession):
+    print(event.value)  # Camera data
+```
+
+Common event types:
+- `CAMERA_MOVE` - Camera position/rotation changes
+- `HAND_MOVE` - Hand tracking data
+- `CLICK` - Element clicks
+- `UPLOAD` - File uploads (returns PIL.Image)
+
+## Custom Routes
+
+```python
+app.add_route("/api/status", lambda: "OK", method="GET")
+```
+
+## Static Files
+
+Files in `static_root` are served at `/static/`:
+```python
+app = Vuer(static_root="./assets")
+# Access at: /static/model.glb
+```
+
+## SSL/TLS (for VR)
+
+VR headsets require secure WebSocket (wss://). Use ngrok:
+
+```bash
+ngrok http 8012
+# Visit: https://vuer.ai?ws=wss://xxxx.ngrok.io
+```
+
+Or configure SSL directly:
+```python
+app = Vuer(
+    cert="/path/to/cert.pem",
+    key="/path/to/key.pem",
+)
+```
+
+## Lifecycle
+
+```python
+app = Vuer()
+
+@app.spawn()
+async def main(session: VuerSession):
+    # Session starts when client connects
+    session.set @ DefaultScene()
+
+    # Keep session alive
+    await session.forever()
+
+    # Or close programmatically
+    session.socket.close()
+
+app.start()  # Blocking call
+```

--- a/skills/vuer/xr.md
+++ b/skills/vuer/xr.md
@@ -1,0 +1,216 @@
+---
+description: Vuer VR/AR/WebXR features - hand tracking, controllers, AR mesh
+topics: [vuer, webxr, vr, ar, hand-tracking, controllers]
+---
+
+# Vuer XR Features
+
+Vuer supports VR/AR through WebXR with hand tracking, motion controllers, and AR mesh detection.
+
+## Requirements
+
+For VR/AR, you need secure WebSocket (wss://). Use ngrok:
+
+```bash
+ngrok http 8012
+# Visit: https://vuer.ai?ws=wss://xxxx.ngrok.io
+```
+
+## Hand Tracking
+
+```python
+from vuer.schemas import DefaultScene, Hands
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Hands(key="hands", stream=True)
+    )
+    await session.forever()
+
+@app.add_handler("HAND_MOVE")
+async def on_hands(event, session):
+    hands = event.value
+    if hands.get('left'):
+        left_hand = hands['left']
+        # Access joint positions
+        wrist = left_hand['wrist']
+        index_tip = left_hand['indexTip']
+        pinch_strength = left_hand.get('pinchStrength', 0)
+```
+
+### Hand Joint Data
+
+Each hand provides:
+- Joint positions: `wrist`, `thumbTip`, `indexTip`, `middleTip`, `ringTip`, `pinkyTip`
+- `pinchStrength` (0-1): Pinch gesture detection
+- `matrix`: Hand transform matrix
+
+## Motion Controllers
+
+```python
+from vuer.schemas import MotionController
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        MotionController(key="controllers", stream=True)
+    )
+    await session.forever()
+
+@app.add_handler("CONTROLLER_MOVE")
+async def on_controller(event, session):
+    data = event.value
+    left = data.get('left')
+    right = data.get('right')
+
+    if right:
+        position = right['position']
+        rotation = right['rotation']
+        buttons = right['buttons']  # Trigger, grip, etc.
+```
+
+## Gripper Visualization
+
+```python
+from vuer.schemas import Gripper
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Gripper(
+            key="gripper",
+            position=[0, 1, -0.5],
+            pinchWidth=0.04,  # Distance between fingers
+        )
+    )
+
+    # Update gripper with hand tracking
+    @app.add_handler("HAND_MOVE")
+    async def update_gripper(event, session):
+        right = event.value.get('right')
+        if right:
+            session.upsert @ Gripper(
+                key="gripper",
+                position=right['wrist'],
+                pinchWidth=0.08 * (1 - right.get('pinchStrength', 0))
+            )
+
+    await session.forever()
+```
+
+## AR Mesh Detection
+
+Detect real-world surfaces in AR:
+
+```python
+from vuer.schemas import WebXRMesh
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        WebXRMesh(key="webxr-mesh", stream=False)
+    )
+
+    await asyncio.sleep(2)  # Wait for mesh detection
+
+    # Request mesh data
+    mesh_data = await session.get_webxr_mesh(key="webxr-mesh")
+
+    for mesh in mesh_data.value.get('meshes', []):
+        vertices = mesh['vertices']
+        indices = mesh['indices']
+        label = mesh.get('semanticLabel', 'unknown')
+        matrix = mesh['matrix']
+        print(f"Mesh: {len(vertices)//3} vertices, label={label}")
+
+    await session.forever()
+```
+
+### Streaming AR Mesh
+
+```python
+WebXRMesh(key="webxr-mesh", stream=True)  # Continuous updates
+```
+
+## Face Tracking
+
+```python
+from vuer.schemas import Facemesh
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        Facemesh(key="face", stream=True)
+    )
+    await session.forever()
+```
+
+## Haptic Feedback
+
+Trigger controller vibration:
+
+```python
+from vuer.events import HapticActuatorPulse
+
+session @ HapticActuatorPulse(
+    left={"strength": 0.5, "duration": 100},   # Left controller
+    right={"strength": 1.0, "duration": 200},  # Right controller
+)
+```
+
+## XR Scene Setup
+
+Complete XR-ready scene:
+
+```python
+from vuer.schemas import (
+    DefaultScene, Hands, MotionController,
+    WebXRMesh, Gripper, Box
+)
+
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    session.set @ DefaultScene(
+        # Hand tracking
+        Hands(key="hands", stream=True),
+
+        # Controller support
+        MotionController(key="controllers", stream=True),
+
+        # AR mesh (AR mode only)
+        WebXRMesh(key="ar-mesh", stream=True),
+
+        # Virtual gripper
+        Gripper(key="gripper"),
+
+        # Scene content
+        Box(key="target", position=[0, 1, -0.5]),
+    )
+    await session.forever()
+```
+
+## Teleportation
+
+Coming soon. For now, use motion controllers to navigate.
+
+## Best Practices
+
+1. **Test on desktop first** - WebXR features gracefully degrade
+2. **Use stream=True sparingly** - High-frequency streaming impacts performance
+3. **Handle missing data** - Not all devices support all features
+4. **Provide fallbacks** - Support both hand tracking and controllers
+
+```python
+@app.add_handler("HAND_MOVE")
+async def on_hands(event, session):
+    if event.value:
+        # Use hand tracking
+        pass
+
+@app.add_handler("CONTROLLER_MOVE")
+async def on_controller(event, session):
+    if event.value:
+        # Use controllers as fallback
+        pass
+```


### PR DESCRIPTION
## Summary

- Add hierarchical skill files under `./skills/` for vuer code assistance
- Main entry point `vuer.md` with sub-skills for server, components, events, examples, and XR features
- Covers core APIs, components, patterns, and VR/AR capabilities

## Skill Structure

```
skills/
├── vuer.md                 # Main entry point
└── vuer/
    ├── components.md       # Component reference (primitives, models, cameras)
    ├── server.md           # Server configuration and lifecycle
    ├── events.md           # Event system and session APIs
    ├── examples.md         # Common patterns and examples
    └── xr.md               # VR/AR/WebXR features
```

## Test plan

- [ ] Verify skill files are correctly formatted markdown with frontmatter
- [ ] Check that examples are syntactically correct Python
- [ ] Review for accuracy against current vuer implementation