### PR TITLE
fix: remove accidental tuple wrapping from physics component defaults

### DIFF
--- a/src/vuer/schemas/physics_components.py
+++ b/src/vuer/schemas/physics_components.py
@@ -30,10 +30,10 @@ class MuJoCo(SceneElement):
     useMocap = True
     gizmoScale = 0.3
 
-    unpauseOnDrag = (False,)  # Whether to unpause the simulation when dragging the object
-    dragForceScale = (1.0,)  # Scale of the drag force applied to the object when dragging
-    showDragArrow = (True,)  # Whether to show the drag arrow when dragging the object
-    showDragForceText = (True,)  # Whether to show the drag force text when dragging the object
+    unpauseOnDrag = False  # Whether to unpause the simulation when dragging the object
+    dragForceScale = 1.0  # Scale of the drag force applied to the object when dragging
+    showDragArrow = True  # Whether to show the drag arrow when dragging the object
+    showDragForceText = True  # Whether to show the drag force text when dragging the object
 
 
 class HandActuator(SceneElement):
@@ -105,5 +105,5 @@ class MjCameraView(SceneElement):
     """
 
     tag = "MjCameraView"
-    movable = (True,)  # Whether the camera can be moved by the user
-    showCameraFrustum = (True,)  # Whether to show the camera  in the scene
+    movable = True  # Whether the camera can be moved by the user
+    showCameraFrustum = True  # Whether to show the camera  in the scene


### PR DESCRIPTION
## Summary
- Fixed incorrect tuple syntax in `MuJoCo` component defaults (`unpauseOnDrag`, `dragForceScale`, `showDragArrow`, `showDragForceText`)
- Fixed incorrect tuple syntax in `MjCameraView` component defaults (`movable`, `showCameraFrustum`)
- Values like `(False,)` are now correctly `False`

## Test plan
- [ ] Verify MuJoCo component initializes with correct default values
- [ ] Verify MjCameraView component initializes with correct default values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @marvinluo1 @geyang