### PR TITLE
feat: rename SceneControl to SceneCameraControl

### DIFF
--- a/src/vuer/schemas/scene_components.py
+++ b/src/vuer/schemas/scene_components.py
@@ -3110,7 +3110,7 @@ class SceneCamera(SceneElement):
   tag = "SceneCamera"
 
 
-class SceneControl(SceneElement):
+class SceneCameraControl(SceneElement):
   """Advanced camera control component.
 
   Provides fine-grained control over camera movement and rotation speeds.
@@ -3127,7 +3127,7 @@ class SceneControl(SceneElement):
   :type truckSpeed: float, optional
   """
 
-  tag = "SceneControl"
+  tag = "SceneCameraControl"
 
 
 class AmbientLightStage(SceneElement):

--- a/src/vuer/schemas/schema.dial
+++ b/src/vuer/schemas/schema.dial
@@ -4455,7 +4455,7 @@
     ]
   },
   {
-    "component": "SceneControl",
+    "component": "SceneCameraControl",
     "schemas": [
       {
         "name": "moveSpeed",


### PR DESCRIPTION
## Summary
- Rename `SceneControl` to `SceneCameraControl` in Python schemas
- Update component tag in `scene_components.py`
- Update schema.dial to match the new component name

This change aligns the Python component naming with the TypeScript implementation.

## Related Changes
**vuer-ts** ([`feat/camera-types-refactor`](https://github.com/vuer-ai/vuer-ts/tree/feat/camera-types-refactor) branch):
- Refactored camera types and added fisheye support
- Renamed `SceneControl.tsx` to `SceneCameraControl.tsx`
- Added camera data extraction utilities
- Updated dial schemas for camera components

## Test plan
- [x] Verify SceneCameraControl component works correctly with the updated Python bindings
- [x] Test camera control functionality in sample scenes
