### PR TITLE
fix: Python 3.14 compatibility for type annotations

### DIFF
--- a/src/vuer/client.py
+++ b/src/vuer/client.py
@@ -32,8 +32,6 @@ import asyncio
 from typing import AsyncIterator, Optional, Union
 
 from msgpack import packb, unpackb
-from params_proto import EnvVar
-
 from vuer.events import ClientEvent, ServerEvent
 
 
@@ -95,17 +93,20 @@ class VuerClient:
         WEBSOCKET_MAX_SIZE: Maximum WebSocket message size (env: WEBSOCKET_MAX_SIZE, default 256MB).
     """
 
-    URI: str = EnvVar @ "VUER_CLIENT_URI" | "ws://localhost:8012"
-    WEBSOCKET_MAX_SIZE: int = EnvVar @ "WEBSOCKET_MAX_SIZE" | 2**28
+    _DEFAULT_URI: str = "ws://localhost:8012"
+    _DEFAULT_MAX_SIZE: int = 2**28
 
     def __init__(self, URI: str = None, WEBSOCKET_MAX_SIZE: int = None):
         """Initialize the Vuer client.
 
-        :param URI: WebSocket URI to connect to (e.g., "ws://localhost:8012")
-        :param WEBSOCKET_MAX_SIZE: Maximum websocket message size in bytes (default 256MB)
+        :param URI: WebSocket URI to connect to (e.g., "ws://localhost:8012").
+            Can also be set via VUER_CLIENT_URI environment variable.
+        :param WEBSOCKET_MAX_SIZE: Maximum websocket message size in bytes (default 256MB).
+            Can also be set via WEBSOCKET_MAX_SIZE environment variable.
         """
-        self.URI = URI if URI is not None else self.__class__.URI
-        self.WEBSOCKET_MAX_SIZE = WEBSOCKET_MAX_SIZE if WEBSOCKET_MAX_SIZE is not None else self.__class__.WEBSOCKET_MAX_SIZE
+        import os
+        self.URI = URI or os.environ.get("VUER_CLIENT_URI", self._DEFAULT_URI)
+        self.WEBSOCKET_MAX_SIZE = WEBSOCKET_MAX_SIZE or int(os.environ.get("WEBSOCKET_MAX_SIZE", self._DEFAULT_MAX_SIZE))
         self._ws = None
         self._connected = False
 

--- a/src/vuer/server.py
+++ b/src/vuer/server.py
@@ -509,9 +509,7 @@ class Vuer(Server):
 
   # Vuer-specific settings (host, cert, key, ca_cert inherited from Server)
   domain: str = EnvVar @ "VUER_DOMAIN" | "https://vuer.ai"
-  client_url: str = Optional[
-    str
-  ]  # Optional override for domain (e.g., local client build)
+  client_url: Optional[str] = None  # Optional override for domain (e.g., local client build)
 
   port: int = EnvVar @ "VUER_PORT" | DEFAULT_PORT
   cors: str = EnvVar @ "VUER_CORS" | DEFAULT_CORS


### PR DESCRIPTION
## Summary
- Fix `client_url` in server.py: was incorrectly using `Optional[str]` as a default value instead of a type annotation
- Fix VuerClient in client.py: `EnvVar @ "..." | default` class attributes weren't resolving properly when accessed via `self.__class__.ATTR`

## Problem
The `Optional[str]` bug caused AttributeError on Python 3.14:
```
AttributeError: 'typing.Union' object has no attribute 'format'
```

The EnvVar bug caused AttributeError when `VuerClient()` was called without explicit parameters:
```
AttributeError: '_EnvVar' object has no attribute 'decode'
```

## Test plan
- [ ] Test `VuerClient()` without explicit parameters on Python 3.13+
- [ ] Test `Vuer()` initialization on Python 3.14