### PR TITLE
feat: add INIT event, session.till(), and spawn filtering

### DIFF
--- a/docs/guides/client_connection.md
+++ b/docs/guides/client_connection.md
@@ -126,6 +126,45 @@ await client.connect()
 await client.close()
 ```
 
+### INIT Event (Automatic)
+
+When a `VuerClient` connects, it automatically sends an `INIT` event with system information. This allows the server to identify the client type and environment.
+
+The INIT event includes:
+
+```python
+{
+    # Common fields (shared with browser client)
+    "client": "python",            # Always "python" for VuerClient
+    "clientVersion": "0.1.x",      # Library version
+    "timezone": "America/Los_Angeles",
+    "timezoneOffset": 480,
+
+    # Python-specific fields
+    "pythonVersion": "3.11.13",
+    "platform": "Darwin",          # or "Linux", "Windows"
+    "platformVersion": "24.2.0",
+    "machine": "arm64",
+}
+```
+
+On the server, you can await this event to identify the client:
+
+```python
+@app.spawn(start=True)
+async def main(session: VuerSession):
+    # Wait for the INIT event
+    e = await session.till("INIT")
+
+    if e.value.get('client') == 'python':
+        print(f"Python client v{e.value.get('clientVersion')}")
+    else:
+        print(f"Browser client: {e.value.get('userAgent')}")
+
+    session.set @ DefaultScene()
+    await session.forever()
+```
+
 ### Sending Events
 
 Define custom event classes by setting `etype` as a class attribute:

--- a/specs/test_init_event.py
+++ b/specs/test_init_event.py
@@ -1,0 +1,262 @@
+"""Tests for INIT event handling and client type filtering.
+
+This file tests the new `till` method for awaiting specific events,
+and the Python client's system info in the INIT event.
+
+Example usage in production:
+
+    @app.spawn(start=True)
+    async def main(session: VuerSession):
+        # Wait for the INIT event from the client
+        e = await session.till("INIT")
+        # or: e = await session.till(event="INIT")
+        client_type = e.value.get('clientType')
+
+        if client_type == 'python':
+            print("Python client connected!")
+            print(f"  Python version: {e.value.get('pythonVersion')}")
+            print(f"  Platform: {e.value.get('platform')}")
+        else:
+            # Browser client
+            print(f"Browser connected: {e.value.get('userAgent')}")
+            print(f"  Screen: {e.value.get('screenWidth')}x{e.value.get('screenHeight')}")
+"""
+
+import asyncio
+
+import pytest
+
+from vuer.client import get_client_info, VuerClient
+from vuer.events import ClientEvent
+
+
+def test_get_client_info_returns_dict():
+    """Test that get_client_info returns a dictionary."""
+    info = get_client_info()
+    assert isinstance(info, dict)
+
+
+def test_get_client_info_has_required_fields():
+    """Test that get_client_info has all required fields."""
+    info = get_client_info()
+
+    # Common fields (shared with browser)
+    common_fields = [
+        "client",
+        "clientVersion",
+        "timezone",
+        "timezoneOffset",
+    ]
+
+    # Python-specific fields
+    python_fields = [
+        "pythonVersion",
+        "platform",
+        "platformVersion",
+        "machine",
+    ]
+
+    for field in common_fields + python_fields:
+        assert field in info, f"Missing required field: {field}"
+
+
+def test_get_client_info_client():
+    """Test that client is always 'python'."""
+    info = get_client_info()
+    assert info["client"] == "python"
+
+
+def test_get_client_info_client_version():
+    """Test that clientVersion is present."""
+    info = get_client_info()
+    assert "clientVersion" in info
+    assert isinstance(info["clientVersion"], str)
+
+
+def test_get_client_info_python_version():
+    """Test that pythonVersion matches platform.python_version()."""
+    import platform
+    info = get_client_info()
+    assert info["pythonVersion"] == platform.python_version()
+
+
+def test_get_client_info_platform():
+    """Test that platform is a recognized value."""
+    import platform as plat
+    info = get_client_info()
+    assert info["platform"] == plat.system()
+    assert info["platform"] in ["Darwin", "Linux", "Windows", "FreeBSD"]
+
+
+def test_get_client_info_platform_version():
+    """Test that platformVersion matches platform.release()."""
+    import platform as plat
+    info = get_client_info()
+    assert info["platformVersion"] == plat.release()
+
+
+def test_get_client_info_machine():
+    """Test that machine matches platform.machine()."""
+    import platform as plat
+    info = get_client_info()
+    assert info["machine"] == plat.machine()
+
+
+def test_get_client_info_timezone():
+    """Test that timezone info is present."""
+    info = get_client_info()
+    # Timezone might be None in some environments
+    assert "timezone" in info
+    assert "timezoneOffset" in info
+
+
+def test_client_event_with_client_info():
+    """Test creating a ClientEvent with client info as value."""
+    info = get_client_info()
+    event = ClientEvent(etype="INIT", value=info)
+
+    assert event.etype == "INIT"
+    assert event.value["client"] == "python"
+    assert "pythonVersion" in event.value
+    assert "platform" in event.value
+
+
+def test_client_event_serialization_with_client_info():
+    """Test that ClientEvent with client info serializes correctly."""
+    info = get_client_info()
+    event = ClientEvent(etype="INIT", value=info)
+    serialized = event._serialize()
+
+    assert serialized["etype"] == "INIT"
+    assert isinstance(serialized["value"], dict)
+    assert serialized["value"]["client"] == "python"
+
+
+class TestVuerClientInit:
+    """Tests for VuerClient INIT event on connect."""
+
+    def test_client_not_connected_initially(self):
+        """Test that client is not connected before calling connect()."""
+        client = VuerClient()
+        assert client.connected is False
+
+    def test_client_has_uri(self):
+        """Test that client has default URI."""
+        client = VuerClient()
+        assert client.URI == "ws://localhost:8012"
+
+
+class TestTillIntegration:
+    """Integration tests for till method.
+
+    These tests require a running server and are marked as slow.
+    Run with: pytest specs/ -m integration
+    """
+
+    @pytest.mark.skip(reason="Requires running server for integration test")
+    async def test_till_receives_init(self):
+        """Test that till receives INIT event from Python client."""
+        # This would require a full server/client setup
+        pass
+
+    @pytest.mark.skip(reason="Requires running server for integration test")
+    async def test_till_timeout(self):
+        """Test that till raises TimeoutError when timeout expires."""
+        pass
+
+
+class TestSpawnFiltering:
+    """Tests for spawn handler filtering."""
+
+    def test_match_filters_empty(self):
+        """Test that empty filters match everything."""
+        from vuer.server import _match_filters
+
+        client_info = {"client": "python", "platform": "Darwin"}
+        assert _match_filters(client_info, {}) is True
+
+    def test_match_filters_exact_match(self):
+        """Test exact match filtering."""
+        from vuer.server import _match_filters
+
+        client_info = {"client": "python", "platform": "Darwin"}
+        assert _match_filters(client_info, {"client": "python"}) is True
+        assert _match_filters(client_info, {"client": "browser"}) is False
+
+    def test_match_filters_wildcard(self):
+        """Test wildcard matching with fnmatch."""
+        from vuer.server import _match_filters
+
+        client_info = {"client": "python", "platform": "Darwin"}
+        assert _match_filters(client_info, {"client": "py*"}) is True
+        assert _match_filters(client_info, {"client": "*thon"}) is True
+        assert _match_filters(client_info, {"client": "??????"}) is True
+        assert _match_filters(client_info, {"client": "other-*"}) is False
+
+    def test_match_filters_multiple_criteria(self):
+        """Test matching with multiple filter criteria."""
+        from vuer.server import _match_filters
+
+        client_info = {"client": "python", "platform": "Darwin", "machine": "arm64"}
+        assert _match_filters(client_info, {"client": "python", "platform": "Darwin"}) is True
+        assert _match_filters(client_info, {"client": "python", "platform": "Linux"}) is False
+        assert _match_filters(client_info, {"client": "py*", "machine": "arm*"}) is True
+
+    def test_match_filters_missing_key(self):
+        """Test that missing keys don't match."""
+        from vuer.server import _match_filters
+
+        client_info = {"client": "python"}
+        assert _match_filters(client_info, {"platform": "Darwin"}) is False
+
+    def test_spawn_decorator_no_args(self):
+        """Test @app.spawn without parentheses."""
+        from vuer import Vuer
+
+        app = Vuer()
+
+        @app.spawn
+        async def handler(session):
+            pass
+
+        assert len(app.spawn_handlers) == 1
+        assert app.spawn_handlers[0]["fn"] == handler
+        assert app.spawn_handlers[0]["filters"] == {}
+
+    def test_spawn_decorator_with_filter(self):
+        """Test @app.spawn(client="python")."""
+        from vuer import Vuer
+
+        app = Vuer()
+
+        @app.spawn(client="python")
+        async def handler(session):
+            pass
+
+        assert len(app.spawn_handlers) == 1
+        # handler variable is now the _SpawnWrapper, but fn is the original function
+        assert app.spawn_handlers[0]["fn"].__name__ == "handler"
+        assert app.spawn_handlers[0]["filters"] == {"client": "python"}
+
+    def test_spawn_decorator_multiple_handlers(self):
+        """Test multiple spawn handlers with different filters."""
+        from vuer import Vuer
+
+        app = Vuer()
+
+        @app.spawn(client="python")
+        async def py_handler(session):
+            pass
+
+        @app.spawn(client="browser")
+        async def ts_handler(session):
+            pass
+
+        @app.spawn
+        async def default_handler(session):
+            pass
+
+        assert len(app.spawn_handlers) == 3
+        assert app.spawn_handlers[0]["filters"] == {"client": "python"}
+        assert app.spawn_handlers[1]["filters"] == {"client": "browser"}
+        assert app.spawn_handlers[2]["filters"] == {}

--- a/src/vuer/client.py
+++ b/src/vuer/client.py
@@ -44,7 +44,7 @@ def get_client_info() -> dict:
   Returns a dictionary with system info for the INIT event:
 
   Common fields (shared with browser client):
-    - client: Always "vuer-py" to distinguish from browser clients
+    - client: Always "python" to distinguish from browser clients
     - clientVersion: The vuer library version
     - timezone: IANA timezone name (e.g., "America/Los_Angeles")
     - timezoneOffset: Timezone offset in minutes from UTC
@@ -86,7 +86,7 @@ def get_client_info() -> dict:
 
   return {
     # Common fields
-    "client": "vuer-py",
+    "client": "python",
     "clientVersion": client_version,
     "timezone": tz_name,
     "timezoneOffset": tz_offset,


### PR DESCRIPTION
## Summary
- Add `get_client_info()` to `VuerClient` for Python system info
- Send INIT event automatically on client connect
- Add `session.till(event)` to await specific events with timeout
- Add `@app.spawn(client="python")` filtering with fnmatch wildcards
- First matching handler runs; warning if multiple match

## Related vuer-ts PRs
- vuer-ai/vuer-ts#145 - refactor: change client identifier from 'vuer-ts' to 'browser'
- vuer-ai/vuer-ts#144 - feat: add display and timezone info to INIT event
- vuer-ai/vuer-ts#143 - refactor: simplify INIT event to essential client info
- vuer-ai/vuer-ts#142 - feat: add client, clientVersion, and runtime to INIT event
- vuer-ai/vuer-ts#141 - feat: add browser info to WebSocket INIT event

## Test plan
- [x] All tests pass: `uv run pytest specs/test_init_event.py -v` (21 passed)