### PR TITLE
feat(workspace): Add link() method and image encoders

### DIFF
--- a/src/vuer/__init__.py
+++ b/src/vuer/__init__.py
@@ -2,10 +2,11 @@ from vuer._compat import handle_server_import_error
 
 try:
     from vuer.server import Vuer, VuerSession
-    from vuer.workspace import Blob, Workspace
+    from vuer.workspace import Blob, Workspace, jpg, png, b64jpg, b64png
 except ImportError as e:
     handle_server_import_error(e)
     Vuer, VuerSession, Workspace, Blob = None, None, None, None
+    jpg, png, b64jpg, b64png = None, None, None, None
 
 from vuer.client import VuerClient
 
@@ -16,4 +17,15 @@ def entrypoint():
     app.run()
 
 
-__all__ = ["Vuer", "VuerSession", "VuerClient", "Workspace", "Blob", "entrypoint"]
+__all__ = [
+    "Vuer",
+    "VuerSession",
+    "VuerClient",
+    "Workspace",
+    "Blob",
+    "jpg",
+    "png",
+    "b64jpg",
+    "b64png",
+    "entrypoint",
+]

--- a/src/vuer/workspace/__init__.py
+++ b/src/vuer/workspace/__init__.py
@@ -3,10 +3,25 @@
 This package provides different workspace implementations for serving
 static files from various storage backends.
 
-Available workspaces:
+**Available workspaces**:
 
 - ``Workspace`` - Local filesystem (default)
 - ``Blob`` - In-memory data with explicit content-type
+
+**Image encoders** (for serving in-memory images):
+
+- ``jpg(image, quality=90)`` - Encode as JPEG bytes
+- ``png(image)`` - Encode as PNG bytes (supports alpha)
+- ``b64jpg(image, quality=90)`` - Encode as base64 JPEG data URI
+- ``b64png(image)`` - Encode as base64 PNG data URI
+
+**Example**::
+
+    from vuer import Workspace, jpg, png
+
+    ws = Workspace()
+    ws.link(lambda: jpg(camera.frame), "/live/frame.jpg")
+    ws.link(lambda: png(depth_map), "/depth.png")
 
 Future workspaces:
 
@@ -24,8 +39,16 @@ from vuer.workspace.workspace import (
     MIME_TYPES,
     ResolveResult,
 )
+from vuer.workspace.encoders import (
+    jpg,
+    png,
+    b64jpg,
+    b64png,
+    decode_b64png,
+)
 
 __all__ = [
+    # Workspace
     "Blob",
     "Workspace",
     "guess_content_type",
@@ -33,4 +56,10 @@ __all__ = [
     "workspace_from_config",
     "MIME_TYPES",
     "ResolveResult",
+    # Encoders
+    "jpg",
+    "png",
+    "b64jpg",
+    "b64png",
+    "decode_b64png",
 ]

--- a/src/vuer/workspace/encoders.py
+++ b/src/vuer/workspace/encoders.py
@@ -1,0 +1,171 @@
+"""Image encoding utilities for serving in-memory images via Workspace.
+
+Provides functions to encode numpy arrays or torch tensors as JPEG/PNG bytes
+or base64 data URIs for embedding in HTML/JSON.
+
+**Usage**::
+
+    from vuer import Workspace, jpg, png
+
+    ws = Workspace()
+    ws.link(lambda: jpg(camera.frame), to="/live/frame.jpg")
+    ws.link(lambda: png(depth_map), to="/depth.png")
+
+**Functions**:
+
+- ``jpg(image, quality=90)`` - Encode as JPEG bytes
+- ``png(image)`` - Encode as PNG bytes (supports alpha)
+- ``b64jpg(image, quality=90)`` - Encode as base64 JPEG data URI
+- ``b64png(image)`` - Encode as base64 PNG data URI
+- ``decode_b64png(b64)`` - Decode base64 PNG back to PIL Image
+
+**Input format**:
+
+Images should be numpy arrays or torch tensors with values in [0, 1] range.
+Shape should be (H, W, C) where C is 1, 3, or 4 channels.
+"""
+
+import base64
+from io import BytesIO
+from typing import Union
+
+import numpy as np
+from PIL import Image
+
+# Type alias for array-like inputs
+ArrayLike = Union[np.ndarray, "torch.Tensor"]
+
+
+def _to_uint8(image: ArrayLike) -> np.ndarray:
+    """Convert image to uint8 numpy array.
+
+    Handles both numpy arrays and torch tensors.
+    Assumes input is in [0, 1] range.
+    """
+    # Convert torch tensor to numpy if needed
+    if hasattr(image, "cpu"):
+        image = image.cpu().numpy()
+
+    # Scale to [0, 255] and convert to uint8
+    image_np = (image * 255).astype(np.uint8)
+
+    # Handle single-channel images
+    if len(image_np.shape) == 3 and image_np.shape[-1] == 1:
+        image_np = image_np[:, :, 0]
+
+    return image_np
+
+
+def jpg(image: ArrayLike, quality: int = 90) -> bytes:
+    """Encode image as JPEG bytes.
+
+    Does not support transparency - alpha channel is stripped.
+
+    :param image: Image array (H, W, C) with values in [0, 1].
+                 Can be numpy array or torch tensor.
+    :param quality: JPEG quality (1-100). Default 90.
+    :return: JPEG-encoded bytes.
+
+    Example::
+
+        frame = camera.capture()  # (480, 640, 3) tensor in [0, 1]
+        data = jpg(frame, quality=85)
+
+        # Use with Workspace
+        ws.link(lambda: jpg(frame), to="/frame.jpg")
+    """
+    # Remove alpha channel if present
+    if len(image.shape) == 3 and image.shape[-1] == 4:
+        image = image[:, :, :3]
+
+    image_np = _to_uint8(image)
+
+    with BytesIO() as buff:
+        pil_image = Image.fromarray(image_np)
+        pil_image.save(buff, format="JPEG", quality=quality)
+        buff.seek(0)
+        return buff.read()
+
+
+def png(image: ArrayLike) -> bytes:
+    """Encode image as PNG bytes.
+
+    Supports transparency (alpha channel).
+
+    :param image: Image array (H, W, C) with values in [0, 1].
+                 Can be numpy array or torch tensor.
+    :return: PNG-encoded bytes.
+
+    Example::
+
+        rgba = render_with_alpha()  # (480, 640, 4) with alpha
+        data = png(rgba)
+
+        # Use with Workspace
+        ws.link(lambda: png(depth_colormap), to="/depth.png")
+    """
+    image_np = _to_uint8(image)
+
+    with BytesIO() as buff:
+        pil_image = Image.fromarray(image_np)
+        pil_image.save(buff, format="PNG")
+        buff.seek(0)
+        return buff.read()
+
+
+def b64jpg(image: ArrayLike, quality: int = 90) -> str:
+    """Encode image as base64 JPEG data URI.
+
+    Returns a string that can be used directly in HTML img src
+    or embedded in JSON responses.
+
+    :param image: Image array (H, W, C) with values in [0, 1].
+    :param quality: JPEG quality (1-100). Default 90.
+    :return: Data URI string like "data:image/jpeg;base64,..."
+
+    Example::
+
+        src = b64jpg(frame)
+        # Use in HTML: <img src="{src}">
+    """
+    data = jpg(image, quality=quality)
+    encoded = base64.b64encode(data).decode("utf-8")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+def b64png(image: ArrayLike) -> str:
+    """Encode image as base64 PNG data URI.
+
+    Returns a string that can be used directly in HTML img src
+    or embedded in JSON responses. Supports alpha channel.
+
+    :param image: Image array (H, W, C) with values in [0, 1].
+    :return: Data URI string like "data:image/png;base64,..."
+
+    Example::
+
+        src = b64png(rgba_image)
+        # Use in HTML: <img src="{src}">
+    """
+    data = png(image)
+    encoded = base64.b64encode(data).decode("utf-8")
+    return f"data:image/png;base64,{encoded}"
+
+
+def decode_b64png(b64: str) -> Image.Image:
+    """Decode a base64 PNG data URI back to a PIL Image.
+
+    :param b64: Base64 string, with or without data URI prefix.
+    :return: PIL Image object.
+
+    Example::
+
+        img = decode_b64png(data_uri)
+        arr = np.array(img) / 255.0  # Back to [0, 1] range
+    """
+    # Strip data URI prefix if present
+    if "," in b64:
+        b64 = b64.split(",")[-1]
+
+    buff = BytesIO(base64.b64decode(b64))
+    return Image.open(buff)


### PR DESCRIPTION
## Summary

- Add `Workspace.link(fn, path)` to serve dynamic content from callables
- Add image encoders module (`jpg`, `png`, `b64jpg`, `b64png`) for serving in-memory images
- Follows `os.link(src, dst)` convention: source first, destination second

## Features

**`link()` method:**
- Auto-detects content-type from path extension (`.jpg` → `image/jpeg`)
- Supports optional request parameter via signature inspection
- Handles bytes, dict/list (JSON), Blob, and string return types

**Image encoders:**
- `jpg(image, quality=90)` → JPEG bytes
- `png(image)` → PNG bytes (supports alpha)
- `b64jpg(image)` → base64 data URI
- `b64png(image)` → base64 data URI

## Usage

```python
from vuer import Workspace, jpg, png

ws = Workspace()

# Serve in-memory images
ws.link(lambda: jpg(camera.frame), "/live/frame.jpg")
ws.link(lambda: png(depth_map), "/depth.png")

# With request param for query args
ws.link(lambda r: render(r.query["angle"]), "/render.jpg")

# JSON endpoint
ws.link(lambda: {"status": "ok"}, "/api/status")
```

## Test plan

- [x] All 33 workspace tests pass
- [x] Tests for link() with bytes, dict, Blob return types
- [x] Tests for content-type auto-detection
- [x] Tests for optional request parameter
- [x] Tests for jpg/png encoders

cc @halo123188 @yanbing-han

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new HTTP handler registration and response-type handling in `Workspace`, which could affect routing/content-type behavior at runtime, though changes are well-covered by new unit tests and are largely additive.
> 
> **Overview**
> Adds `Workspace.link(fn, to=...)` as a new dynamic endpoint mechanism (replacing documented `route()`), including optional request parameter support via signature inspection, automatic content-type inference from the URL extension, and expanded return-type handling (JSON for `dict`/`list`, binary `bytes`, `Blob`, or `str`).
> 
> Introduces `workspace.encoders` with `jpg`/`png` byte encoders and `b64jpg`/`b64png` data-URI helpers (plus `decode_b64png`), exports them from `vuer`/`vuer.workspace`, updates docs/READMEs accordingly, and adds comprehensive tests for `link()` behavior and the new image encoders.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cd15bacd664ba05125beaecef773b99f86bf23b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->