### PR TITLE
feat: add ViewportHud and Simple Camera schemas

### DIFF
--- a/src/vuer/schemas/drei_components.py
+++ b/src/vuer/schemas/drei_components.py
@@ -363,6 +363,102 @@ class OrthographicCamera(SceneElement):
     key = "orthographic-camera"
 
 
+class SimplePerspectiveCamera(SceneElement):
+    """Simple perspective camera wrapper with UI-exposed properties.
+
+    A lightweight wrapper around Drei's PerspectiveCamera with properties
+    exposed for UI controls. Suitable for use inside ViewportHud or as
+    a standalone camera.
+
+    :param position: Camera position as [x, y, z]. Default: [0, 0, 5]
+    :type position: list[float], optional
+    :param rotation: Camera rotation in Euler angles [x, y, z]. Default: [0, 0, 0]
+    :type rotation: list[float], optional
+    :param fov: Vertical field of view in degrees (1-180). Default: 50
+    :type fov: float, optional
+    :param aspect: Aspect ratio (width/height). Default: 1.777
+    :type aspect: float, optional
+    :param near: Near clipping plane distance. Default: 0.1
+    :type near: float, optional
+    :param far: Far clipping plane distance. Default: 1000
+    :type far: float, optional
+    :param zoom: Zoom factor. Default: 1.0
+    :type zoom: float, optional
+    :param makeDefault: Make this the default camera. Default: False
+    :type makeDefault: bool, optional
+    :param manual: Disable auto-update of projection matrix. Default: False
+    :type manual: bool, optional
+
+    Example Usage::
+
+        from vuer.schemas import SimplePerspectiveCamera, ViewportHud
+
+        # Inside a ViewportHud
+        ViewportHud(
+            SimplePerspectiveCamera(position=[0, 0, 5], fov=50, makeDefault=True),
+            Box(args=[1, 1, 1]),
+            top=10,
+            right=10,
+            width=200,
+            height=150,
+        )
+    """
+
+    tag = "SimplePerspectiveCamera"
+
+
+class SimpleOrthographicCamera(SceneElement):
+    """Simple orthographic camera wrapper with UI-exposed properties.
+
+    A lightweight wrapper around Drei's OrthographicCamera with properties
+    exposed for UI controls. Renders objects at the same size regardless
+    of distance. Suitable for use inside ViewportHud or as a standalone camera.
+
+    :param position: Camera position as [x, y, z]. Default: [0, 0, 5]
+    :type position: list[float], optional
+    :param rotation: Camera rotation in Euler angles [x, y, z]. Default: [0, 0, 0]
+    :type rotation: list[float], optional
+    :param left: Left boundary of view frustum. Default: -5
+    :type left: float, optional
+    :param right: Right boundary of view frustum. Default: 5
+    :type right: float, optional
+    :param top: Top boundary of view frustum. Default: 5
+    :type top: float, optional
+    :param bottom: Bottom boundary of view frustum. Default: -5
+    :type bottom: float, optional
+    :param near: Near clipping plane distance. Default: 0.1
+    :type near: float, optional
+    :param far: Far clipping plane distance. Default: 1000
+    :type far: float, optional
+    :param zoom: Zoom factor. Default: 1.0
+    :type zoom: float, optional
+    :param makeDefault: Make this the default camera. Default: False
+    :type makeDefault: bool, optional
+    :param manual: Disable auto-update of projection matrix. Default: False
+    :type manual: bool, optional
+
+    Example Usage::
+
+        from vuer.schemas import SimpleOrthographicCamera, ViewportHud
+
+        # Inside a ViewportHud for 2D-style rendering
+        ViewportHud(
+            SimpleOrthographicCamera(
+                position=[0, 0, 10],
+                left=-5, right=5, top=5, bottom=-5,
+                makeDefault=True
+            ),
+            Box(args=[1, 1, 1]),
+            bottom=10,
+            left=10,
+            width=200,
+            height=150,
+        )
+    """
+
+    tag = "SimpleOrthographicCamera"
+
+
 class FisheyeCamera(SceneElement):
     """Fisheye camera with ultra-wide angle projection.
 

--- a/src/vuer/schemas/scene_components.py
+++ b/src/vuer/schemas/scene_components.py
@@ -2837,6 +2837,67 @@ class GrabRender(SceneElement):
   key = "DEFAULT"
 
 
+class ViewportHud(SceneElement):
+  """A HUD (Heads-Up Display) component that renders to a specific viewport region.
+
+  Creates an isolated render scene within a rectangular region of the canvas,
+  using CSS-like positioning (top, right, bottom, left). Useful for mini-maps,
+  picture-in-picture views, auxiliary camera feeds, or UI overlays.
+
+  The viewport uses a separate scene and camera, so children are rendered
+  independently of the main scene. You must include a camera (SimplePerspectiveCamera
+  or SimpleOrthographicCamera) as a child with makeDefault=True.
+
+  **Positioning:**
+
+  Position values can be numbers (pixels) or strings with '%' (percentage).
+  Use top/left for top-left anchoring, or bottom/right for other corners.
+
+  :param top: Distance from top edge (pixels or percentage string like '10%')
+  :type top: int | str, optional
+  :param right: Distance from right edge (pixels or percentage string like '10%')
+  :type right: int | str, optional
+  :param bottom: Distance from bottom edge (pixels or percentage string like '10%')
+  :type bottom: int | str, optional
+  :param left: Distance from left edge (pixels or percentage string like '10%')
+  :type left: int | str, optional
+  :param width: Width of the viewport (pixels or percentage). Required.
+  :type width: int | str
+  :param height: Height of the viewport (pixels or percentage). Required.
+  :type height: int | str
+  :param renderPriority: Render priority (1-10). Default: 1
+  :type renderPriority: int, optional
+
+  Example Usage::
+
+      from vuer.schemas import ViewportHud, SimplePerspectiveCamera, Box
+
+      # Mini-map in top-right corner (pixel positioning)
+      ViewportHud(
+          SimplePerspectiveCamera(position=[0, 10, 0], rotation=[-1.57, 0, 0], makeDefault=True),
+          Box(args=[1, 1, 1], materialColor="red"),
+          top=10,
+          right=10,
+          width=200,
+          height=150,
+          key="minimap"
+      )
+
+      # Picture-in-picture with percentage positioning
+      ViewportHud(
+          SimplePerspectiveCamera(position=[5, 5, 5], makeDefault=True),
+          Box(args=[1, 1, 1], materialColor="blue"),
+          bottom="5%",
+          left="5%",
+          width="20%",
+          height="25%",
+          key="pip"
+      )
+  """
+
+  tag = "ViewportHud"
+
+
 class TimelineControls(SceneElement):
   tag = "TimelineControls"
 


### PR DESCRIPTION
## Summary

Add Python schemas for three new TypeScript components that enable independent HUD rendering at arbitrary canvas positions.

### New Schemas

1. **ViewportHud** (`scene_components.py`)
   - HUD component that renders children to a specific viewport region
   - CSS-like positioning with `top`, `right`, `bottom`, `left` (pixels or percentage strings)
   - Required `width` and `height` props
   - Optional `renderPriority` for render order control

2. **SimplePerspectiveCamera** (`drei_components.py`)
   - Simple perspective camera wrapper for use in ViewportHud or standalone
   - Props: `position`, `rotation`, `fov`, `aspect`, `near`, `far`, `zoom`, `makeDefault`, `manual`

3. **SimpleOrthographicCamera** (`drei_components.py`)
   - Simple orthographic camera wrapper for 2D-style rendering
   - Props: `position`, `rotation`, `left`, `right`, `top`, `bottom`, `near`, `far`, `zoom`, `makeDefault`, `manual`

### Example Usage

```python
from vuer.schemas import ViewportHud, SimplePerspectiveCamera, SimpleOrthographicCamera, Box

# Mini-map in top-right corner
ViewportHud(
    SimplePerspectiveCamera(position=[0, 10, 0], rotation=[-1.57, 0, 0], makeDefault=True),
    Box(args=[1, 1, 1], materialColor="red"),
    top=10,
    right=10,
    width=200,
    height=150,
    key="minimap"
)

# Picture-in-picture with percentage positioning
ViewportHud(
    SimpleOrthographicCamera(position=[0, 0, 10], makeDefault=True),
    Box(args=[1, 1, 1], materialColor="blue"),
    bottom="5%",
    left="5%",
    width="20%",
    height="25%",
    key="pip"
)
```

### Related PRs

- vuer-ts: https://github.com/vuer-ai/vuer-ts/pull/158

## Test Plan

- [ ] Verify schemas import correctly: `from vuer.schemas import ViewportHud, SimplePerspectiveCamera, SimpleOrthographicCamera`
- [ ] Test with vuer-ts frontend after both PRs are merged