### PR TITLE
fix(schemas): handle dict children in BlockElement._serialize

### DIFF
--- a/src/vuer/schemas/html_components.py
+++ b/src/vuer/schemas/html_components.py
@@ -95,7 +95,7 @@ class BlockElement(Element):
     result = super()._serialize()
     if children := getattr(self, "children", None):
       result["children"] = [
-        e if isinstance(e, str) else e._serialize() for e in children
+        e if isinstance(e, (str, dict)) else e._serialize() for e in children
       ]
     return result
 


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'dict' object has no attribute '_serialize'` when calling `store.scene._serialize()`
- `SceneStore.scene` returns a Scene with dict children (from `to_scene()`), but `_serialize()` was trying to call `e._serialize()` on them
- Now dict children are passed through as-is, similar to string children

## Test plan
- [x] Verified `store.scene._serialize()` works correctly
- [x] Verified serialization output matches original scene
- [x] Existing tests pass (31/32, 1 pre-existing failure unrelated to this change)