### PR TITLE
feat(schemas): add InPlaceDepthPointCloud and minY/maxY filtering

### DIFF
--- a/src/vuer/rtc/__tests__/test_scene_store_upsert_to.py
+++ b/src/vuer/rtc/__tests__/test_scene_store_upsert_to.py
@@ -34,6 +34,7 @@ class TestUpsertToNestedParent:
   async def test_upsert_to_depth_point_cloud_provider(self):
     """Test upserting a DepthPointCloud into a DepthPointCloudProvider."""
     store = SceneStore()
+
     session = MockSession()
 
     async with store.subscribe(session):

--- a/src/vuer/schemas/scene_components.py
+++ b/src/vuer/schemas/scene_components.py
@@ -3576,6 +3576,14 @@ class DepthPointCloud(SceneElement):
        - float
        - 2
        - Maximum height for visualization mapping
+     * - minY
+       - float
+       - -Infinity
+       - Minimum world Y for filtering - points below this are discarded
+     * - maxY
+       - float
+       - Infinity
+       - Maximum world Y for filtering - points above this are discarded
      * - hide
        - bool
        - False
@@ -3644,6 +3652,99 @@ class DepthPointCloudProvider(SceneElement):
 
   tag = "DepthPointCloudProvider"
   children = []
+
+
+class InPlaceDepthPointCloud(SceneElement):
+  """In Place Updated Depth-based point cloud component with LoD rendering.
+
+  Renders a point cloud from depth and RGB images with support for
+  multiple colormap visualizations and level-of-detail rendering.
+
+  **Parameters:**
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 20 15 10 55
+
+     * - Parameter
+       - Type
+       - Default
+       - Description
+     * - depth
+       - str
+       - (required)
+       - URL to 16-bit depth PNG image
+     * - rgb
+       - str
+       - None
+       - URL to RGB image (uses depth grayscale if not provided)
+     * - position
+       - tuple
+       - [0, 0, 0]
+       - Position in 3D space [x, y, z]
+     * - rotation
+       - tuple
+       - [0, 0, 0]
+       - Rotation in Euler angles [x, y, z]
+     * - scale
+       - tuple
+       - [1, 1, 1]
+       - Scale factors [x, y, z]
+     * - fov
+       - float
+       - 58
+       - Vertical field of view in degrees (58 = RealSense D435)
+     * - depthUnit
+       - float
+       - 0.001
+       - Depth scale factor - converts raw depth values to meters
+     * - pointSize
+       - float
+       - 2.0
+       - Point size in pixels or world units
+     * - screenSpaceSizing
+       - bool
+       - True
+       - If true, points have constant pixel size
+     * - cmap
+       - str
+       - None
+       - Colormap: "turbo", "viridis", "inferno", "jet", or None for RGB
+     * - colorMode
+       - str
+       - "depth"
+       - Color mode: "depth", "camZ", "camDist", "localY", "worldY"
+     * - depthMin
+       - float
+       - 0.1
+       - Minimum depth for visualization mapping
+     * - depthMax
+       - float
+       - 50
+       - Maximum depth for visualization mapping
+     * - heightMin
+       - float
+       - -2
+       - Minimum height for visualization mapping
+     * - heightMax
+       - float
+       - 2
+       - Maximum height for visualization mapping
+     * - minY
+       - float
+       - -Infinity
+       - Minimum world Y for filtering - points below this are discarded
+     * - maxY
+       - float
+       - Infinity
+       - Maximum world Y for filtering - points above this are discarded
+     * - hide
+       - bool
+       - False
+       - Hide this point cloud
+  """
+
+  tag = "InPlaceDepthPointCloud"
 
 
 class SceneCamera(SceneElement):


### PR DESCRIPTION
## Summary
- Add `InPlaceDepthPointCloud` component for in-place updated point cloud rendering
- Add `minY`/`maxY` parameters to `DepthPointCloud` for world Y coordinate filtering

## Changes
- `InPlaceDepthPointCloud`: New component with same parameters as `DepthPointCloud` but designed for in-place updates
- `DepthPointCloud.minY`: Minimum world Y for filtering (points below are discarded)
- `DepthPointCloud.maxY`: Maximum world Y for filtering (points above are discarded)

## Test plan
- [ ] Verify component renders correctly in frontend