### PR TITLE
feat: track and cancel async tasks per websocket session

### DIFF
--- a/src/vuer/rtc/scene_store.py
+++ b/src/vuer/rtc/scene_store.py
@@ -24,269 +24,271 @@ Usage:
             print(store.history)  # Complete operation history
 """
 
-import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set as TypeSet
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import Set as TypeSet
 
 from vuer.events import Add, Remove, Set, Update, Upsert
 from vuer.schemas import Scene
 from vuer.server import SceneOps
 
 if TYPE_CHECKING:
-    from vuer.server import VuerSession
+  from vuer.server import VuerSession
 
 
 def _serialize(element) -> Dict[str, Any]:
-    """Serialize an element to dict."""
-    if hasattr(element, "_serialize"):
-        return element._serialize()
-    elif isinstance(element, dict):
-        return element
-    else:
-        return dict(element)
+  """Serialize an element to dict."""
+  if hasattr(element, "_serialize"):
+    return element._serialize()
+  elif isinstance(element, dict):
+    return element
+  else:
+    return dict(element)
 
 
 class SceneGraph:
-    """
-    Scene state model that manages the scene graph as a nested dict structure.
+  """
+  Scene state model that manages the scene graph as a nested dict structure.
 
-    Provides methods for manipulating the scene: set, add, update, upsert, remove.
-    Can hydrate back to a Scene object via to_scene().
-    """
+  Provides methods for manipulating the scene: set, add, update, upsert, remove.
+  Can hydrate back to a Scene object via to_scene().
+  """
 
-    def __init__(self):
-        self._data: Optional[Dict[str, Any]] = None
+  def __init__(self):
+    self._data: Optional[Dict[str, Any]] = None
 
-    @property
-    def data(self) -> Optional[Dict[str, Any]]:
-        """Get raw scene data as dict."""
-        return self._data
+  @property
+  def data(self) -> Optional[Dict[str, Any]]:
+    """Get raw scene data as dict."""
+    return self._data
 
-    def set_scene(self, scene_data: Dict[str, Any]) -> None:
-        """Set the entire scene."""
-        self._data = scene_data
+  def set_scene(self, scene_data: Dict[str, Any]) -> None:
+    """Set the entire scene."""
+    self._data = scene_data
 
-    def get(self, key: str) -> Optional[Dict[str, Any]]:
-        """Get element by key (recursive search)."""
-        if not self._data:
-            return None
-        return self._find_by_key(self._data.get("children", []), key)
+  def get(self, key: str) -> Optional[Dict[str, Any]]:
+    """Get element by key (recursive search)."""
+    if not self._data:
+      return None
+    return self._find_by_key(self._data.get("children", []), key)
 
-    def add(self, node: Dict[str, Any], to: Optional[str] = None) -> None:
-        """Add a node to the scene."""
-        if not self._data:
-            return
-        if to:
-            parent = self.get(to)
-            if parent:
-                children = parent.setdefault("children", [])
-                children.append(node)
+  def add(self, node: Dict[str, Any], to: Optional[str] = None) -> None:
+    """Add a node to the scene."""
+    if not self._data:
+      return
+    if to:
+      parent = self.get(to)
+      if parent:
+        children = parent.setdefault("children", [])
+        children.append(node)
+    else:
+      self._data.setdefault("children", []).append(node)
+
+  def update(self, node: Dict[str, Any]) -> None:
+    """Update an existing node by key."""
+    if not self._data:
+      return
+    key = node.get("key")
+    if key:
+      existing = self.get(key)
+      if existing:
+        existing.update(node)
+
+  def upsert(self, node: Dict[str, Any], to: Optional[str] = None) -> None:
+    """Update if exists, otherwise add."""
+    if not self._data:
+      return
+    children = self._data.get("children", [])
+    self._data["children"] = self._upsert_into(children, node, to)
+
+  def remove(self, key: str) -> None:
+    """Remove a node by key."""
+    if not self._data:
+      return
+    children = self._data.get("children", [])
+    self._data["children"] = self._remove_by_key(children, key)
+
+  def to_scene(self) -> Optional[Scene]:
+    """Hydrate the scene data back to a Scene object."""
+    if not self._data:
+      return None
+    # Extract children and scene-level props
+    children_data = self._data.get("children", [])
+    # Scene expects children as positional args, other props as kwargs
+    # Filter out empty lists and None values
+    skip_keys = {"tag", "children", "bgChildren", "rawChildren", "htmlChildren"}
+    props = {
+      k: v for k, v in self._data.items() if k not in skip_keys and v is not None
+    }
+    return Scene(*children_data, **props)
+
+  # =========================================================================
+  # Internal helpers
+  # =========================================================================
+
+  def _find_by_key(self, children: List[Dict], key: str) -> Optional[Dict]:
+    """Find element by key in children list (recursive)."""
+    for child in children:
+      if child.get("key") == key:
+        return child
+      nested = child.get("children", [])
+      if nested:
+        found = self._find_by_key(nested, key)
+        if found:
+          return found
+    return None
+
+  def _remove_by_key(self, children: List[Dict], key: str) -> List[Dict]:
+    """Remove element by key from children list (recursive)."""
+    result = []
+    for child in children:
+      if child.get("key") == key:
+        continue
+      nested = child.get("children", [])
+      if nested:
+        child = {**child, "children": self._remove_by_key(nested, key)}
+      result.append(child)
+    return result
+
+  def _upsert_into(
+    self, children: List[Dict], element: Dict, to: Optional[str] = None
+  ) -> List[Dict]:
+    """Upsert element into children list."""
+    key = element.get("key")
+
+    # If targeting a parent, find it and add there
+    if to:
+      result = []
+      for child in children:
+        if child.get("key") == to:
+          nested = child.get("children", [])
+          child = {**child, "children": self._upsert_into(nested, element)}
         else:
-            self._data.setdefault("children", []).append(node)
+          nested = child.get("children", [])
+          if nested:
+            child = {**child, "children": self._upsert_into(nested, element, to)}
+        result.append(child)
+      return result
 
-    def update(self, node: Dict[str, Any]) -> None:
-        """Update an existing node by key."""
-        if not self._data:
-            return
-        key = node.get("key")
-        if key:
-            existing = self.get(key)
-            if existing:
-                existing.update(node)
+    # Check if exists (update) or not (add)
+    found = False
+    result = []
+    for child in children:
+      if child.get("key") == key:
+        result.append({**child, **element})
+        found = True
+      else:
+        nested = child.get("children", [])
+        if nested:
+          child = {**child, "children": self._upsert_into(nested, element)}
+        result.append(child)
 
-    def upsert(self, node: Dict[str, Any], to: Optional[str] = None) -> None:
-        """Update if exists, otherwise add."""
-        if not self._data:
-            return
-        children = self._data.get("children", [])
-        self._data["children"] = self._upsert_into(children, node, to)
+    if not found:
+      result.append(element)
 
-    def remove(self, key: str) -> None:
-        """Remove a node by key."""
-        if not self._data:
-            return
-        children = self._data.get("children", [])
-        self._data["children"] = self._remove_by_key(children, key)
-
-    def to_scene(self) -> Optional[Scene]:
-        """Hydrate the scene data back to a Scene object."""
-        if not self._data:
-            return None
-        # Extract children and scene-level props
-        children_data = self._data.get("children", [])
-        # Scene expects children as positional args, other props as kwargs
-        # Filter out empty lists and None values
-        skip_keys = {"tag", "children", "bgChildren", "rawChildren", "htmlChildren"}
-        props = {k: v for k, v in self._data.items() if k not in skip_keys and v is not None}
-        return Scene(*children_data, **props)
-
-    # =========================================================================
-    # Internal helpers
-    # =========================================================================
-
-    def _find_by_key(self, children: List[Dict], key: str) -> Optional[Dict]:
-        """Find element by key in children list (recursive)."""
-        for child in children:
-            if child.get("key") == key:
-                return child
-            nested = child.get("children", [])
-            if nested:
-                found = self._find_by_key(nested, key)
-                if found:
-                    return found
-        return None
-
-    def _remove_by_key(self, children: List[Dict], key: str) -> List[Dict]:
-        """Remove element by key from children list (recursive)."""
-        result = []
-        for child in children:
-            if child.get("key") == key:
-                continue
-            nested = child.get("children", [])
-            if nested:
-                child = {**child, "children": self._remove_by_key(nested, key)}
-            result.append(child)
-        return result
-
-    def _upsert_into(self, children: List[Dict], element: Dict, to: Optional[str] = None) -> List[Dict]:
-        """Upsert element into children list."""
-        key = element.get("key")
-
-        # If targeting a parent, find it and add there
-        if to:
-            result = []
-            for child in children:
-                if child.get("key") == to:
-                    nested = child.get("children", [])
-                    child = {**child, "children": self._upsert_into(nested, element)}
-                else:
-                    nested = child.get("children", [])
-                    if nested:
-                        child = {**child, "children": self._upsert_into(nested, element, to)}
-                result.append(child)
-            return result
-
-        # Check if exists (update) or not (add)
-        found = False
-        result = []
-        for child in children:
-            if child.get("key") == key:
-                result.append({**child, **element})
-                found = True
-            else:
-                nested = child.get("children", [])
-                if nested:
-                    child = {**child, "children": self._upsert_into(nested, element)}
-                result.append(child)
-
-        if not found:
-            result.append(element)
-
-        return result
+    return result
 
 
 class SubscriptionContext:
-    """Context manager for session subscription."""
+  """Context manager for session subscription."""
 
-    def __init__(self, store: "SceneStore", session: "VuerSession"):
-        self.store = store
-        self.session = session
+  def __init__(self, store: "SceneStore", session: "VuerSession"):
+    self.store = store
+    self.session = session
 
-    async def __aenter__(self) -> "SubscriptionContext":
-        self.store._add_subscriber(self.session)
-        return self
+  async def __aenter__(self) -> "SubscriptionContext":
+    self.store._add_subscriber(self.session)
+    return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        self.store._remove_subscriber(self.session)
-        return None
+  async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    self.store._remove_subscriber(self.session)
+    return None
 
 
 class SceneStore(SceneOps):
-    """
-    A reactive store that maintains scene state and broadcasts to subscribers.
+  """
+  A reactive store that maintains scene state and broadcasts to subscribers.
 
-    Inherits from SceneOps which provides: set, add, upsert, update, remove.
-    Uses SceneGraph internally for state management.
+  Inherits from SceneOps which provides: set, add, upsert, update, remove.
+  Uses SceneGraph internally for state management.
 
-    Example:
-        store = SceneStore()
+  Example:
+      store = SceneStore()
 
-        @app.spawn(start=True)
-        async def main(sess: VuerSession):
-            async with store.subscribe(sess):
-                store.set @ Scene(Box(key="box"))
-                store.upsert @ Sphere(key="sphere", position=[1, 0, 0])
+      @app.spawn(start=True)
+      async def main(sess: VuerSession):
+          async with store.subscribe(sess):
+              store.set @ Scene(Box(key="box"))
+              store.upsert @ Sphere(key="sphere", position=[1, 0, 0])
 
-                # Query state
-                print(store.get("box"))
-                print(store.scene)  # Returns Scene object
-                print(store.history)
-    """
+              # Query state
+              print(store.get("box"))
+              print(store.scene)  # Returns Scene object
+              print(store.history)
+  """
 
-    def __init__(self):
-        self._subscribers: TypeSet["VuerSession"] = set()
-        self._graph = SceneGraph()
-        self._history: List[Dict[str, Any]] = []
+  def __init__(self):
+    self._subscribers: TypeSet["VuerSession"] = set()
+    self._graph = SceneGraph()
+    self._history: List[Dict[str, Any]] = []
 
-    @property
-    def history(self) -> List[Dict[str, Any]]:
-        """Get complete history of all operations."""
-        return self._history
+  @property
+  def history(self) -> List[Dict[str, Any]]:
+    """Get complete history of all operations."""
+    return self._history
 
-    @property
-    def scene(self) -> Optional[Scene]:
-        """Get current scene as a hydrated Scene object."""
-        return self._graph.to_scene()
+  @property
+  def scene(self) -> Optional[Scene]:
+    """Get current scene as a hydrated Scene object."""
+    return self._graph.to_scene()
 
-    @property
-    def scene_data(self) -> Optional[Dict[str, Any]]:
-        """Get current scene state as raw dict."""
-        return self._graph.data
+  @property
+  def scene_data(self) -> Optional[Dict[str, Any]]:
+    """Get current scene state as raw dict."""
+    return self._graph.data
 
-    def get(self, key: str) -> Optional[Dict[str, Any]]:
-        """Get element by key."""
-        return self._graph.get(key)
+  def get(self, key: str) -> Optional[Dict[str, Any]]:
+    """Get element by key."""
+    return self._graph.get(key)
 
-    def subscribe(self, session: "VuerSession") -> SubscriptionContext:
-        """Subscribe a session to receive broadcasts."""
-        return SubscriptionContext(self, session)
+  def subscribe(self, session: "VuerSession") -> SubscriptionContext:
+    """Subscribe a session to receive broadcasts."""
+    return SubscriptionContext(self, session)
 
-    def _add_subscriber(self, session: "VuerSession") -> None:
-        self._subscribers.add(session)
+  def _add_subscriber(self, session: "VuerSession") -> None:
+    self._subscribers.add(session)
 
-    def _remove_subscriber(self, session: "VuerSession") -> None:
-        self._subscribers.discard(session)
+  def _remove_subscriber(self, session: "VuerSession") -> None:
+    self._subscribers.discard(session)
 
-    def __matmul__(self, event) -> None:
-        """Central dispatch for all operations - updates state, records history, broadcasts."""
-        # Record to history
-        self._history.append({
-            "etype": event.etype.lower(),
-            "timestamp": time.time(),
-            "event": event._serialize(),
-        })
+  def __matmul__(self, event) -> None:
+    """Central dispatch for all operations - updates state, records history, broadcasts."""
+    # Record to history
+    _event = deepcopy(event)
+    # self._history.append(_event)
 
-        # Update internal state via SceneGraph
-        if isinstance(event, Set):
-            self._graph.set_scene(_serialize(event.data))
+    # Update internal state via SceneGraph
+    if isinstance(event, Set):
+      self._graph.set_scene(_serialize(event.data))
 
-        elif isinstance(event, Update):
-            for node in event.data["nodes"]:
-                self._graph.update(_serialize(node))
+    elif isinstance(event, Update):
+      for node in event.data["nodes"]:
+        self._graph.update(_serialize(node))
 
-        elif isinstance(event, Add):
-            to = event.data.get("to")
-            for node in event.data["nodes"]:
-                self._graph.add(_serialize(node), to=to)
+    elif isinstance(event, Add):
+      to = event.data.get("to")
+      for node in event.data["nodes"]:
+        self._graph.add(_serialize(node), to=to)
 
-        elif isinstance(event, Upsert):
-            to = event.data.get("to")
-            for node in event.data["nodes"]:
-                self._graph.upsert(_serialize(node), to=to)
+    elif isinstance(event, Upsert):
+      to = event.data.get("to")
+      for node in event.data["nodes"]:
+        self._graph.upsert(_serialize(node), to=to)
 
-        elif isinstance(event, Remove):
-            for key in event.data["keys"]:
-                self._graph.remove(key)
+    elif isinstance(event, Remove):
+      for key in event.data["keys"]:
+        self._graph.remove(key)
 
-        # Broadcast to all subscribers
-        for session in self._subscribers:
-            session @ event
+    # Broadcast to all subscribers
+    for session in self._subscribers:
+      session @ event

--- a/src/vuer/schemas/scene_components.py
+++ b/src/vuer/schemas/scene_components.py
@@ -3946,18 +3946,21 @@ class Scene(BlockElement):
     super().__init__(*children, up=up, **kwargs)
 
     # Set bgChildren: use user-provided value, or empty list if None
-    self.bgChildren = bgChildren if bgChildren is not None else []
+    if bgChildren:
+      self.bgChildren = bgChildren
 
     if rawChildren is None:
-      self.rawChildren = []
+        pass
     elif isinstance(rawChildren, list):
       self.rawChildren = rawChildren
     else:
       self.rawChildren = [rawChildren]
 
-    self.htmlChildren = htmlChildren or []
+    if htmlChildren:
+      self.htmlChildren = htmlChildren
 
     self.up = up
+
     if background:
       self.background = background
 
@@ -3976,12 +3979,13 @@ class Scene(BlockElement):
 
   def _serialize(self):
     obj = super()._serialize()
-    if self.rawChildren:
+    if getattr(self, 'rawChildren', None):
       obj["rawChildren"] = [e._serialize() for e in self.rawChildren if e]
-    if self.htmlChildren:
+    if getattr(self, 'htmlChildren', None):
       obj["htmlChildren"] = [e._serialize() for e in self.htmlChildren if e]
-    if self.bgChildren:
+    if getattr(self, 'bgChildren', None):
       obj["bgChildren"] = [e._serialize() for e in self.bgChildren if e]
+      print(obj)
     return obj
 
 

--- a/src/vuer/workspace/workspace.py
+++ b/src/vuer/workspace/workspace.py
@@ -60,32 +60,33 @@ from aiohttp import web
 
 
 class MimeTypes(dict):
-    """Dict subclass for MIME type mappings with a guess method.
+  """Dict subclass for MIME type mappings with a guess method.
 
-    Example::
+  Example::
 
-        MIME_TYPES[".npy"] = "application/x-npy"
-        content_type = MIME_TYPES.guess("data.npy")
+      MIME_TYPES[".npy"] = "application/x-npy"
+      content_type = MIME_TYPES.guess("data.npy")
+  """
+
+  def guess(self, filename: str) -> str:
+    """Guess content-type from filename.
+
+    Checks this dict first, then falls back to Python's mimetypes module.
+
+    :param filename: Filename or path to guess type for.
+    :return: MIME type string.
     """
-
-    def guess(self, filename: str) -> str:
-        """Guess content-type from filename.
-
-        Checks this dict first, then falls back to Python's mimetypes module.
-
-        :param filename: Filename or path to guess type for.
-        :return: MIME type string.
-        """
-        ext = Path(filename).suffix.lower()
-        if ext in self:
-            return self[ext]
-        mime_type, _ = mimetypes.guess_type(filename)
-        return mime_type or "application/octet-stream"
+    ext = Path(filename).suffix.lower()
+    if ext in self:
+      return self[ext]
+    mime_type, _ = mimetypes.guess_type(filename)
+    return mime_type or "application/octet-stream"
 
 
 # Extended MIME types for robotics files.
 # Add custom types: MIME_TYPES[".custom"] = "application/x-custom"
-MIME_TYPES = MimeTypes({
+MIME_TYPES = MimeTypes(
+  {
     ".urdf": "application/xml",
     ".xacro": "application/xml",
     ".srdf": "application/xml",
@@ -102,79 +103,81 @@ MIME_TYPES = MimeTypes({
     ".json": "application/json",
     ".yaml": "application/x-yaml",
     ".yml": "application/x-yaml",
-})
+  }
+)
 
 
 def guess_content_type(filename: str) -> str:
-    """Guess content-type from filename, with robotics file support.
+  """Guess content-type from filename, with robotics file support.
 
-    Convenience function that calls MIME_TYPES.guess().
-    """
-    return MIME_TYPES.guess(filename)
+  Convenience function that calls MIME_TYPES.guess().
+  """
+  return MIME_TYPES.guess(filename)
 
 
 def sanitize_path(filename: str) -> str:
-    """Sanitize a filename to prevent path traversal attacks.
+  """Sanitize a filename to prevent path traversal attacks.
 
-    - Strips leading slashes (absolute paths)
-    - Removes '..' components
-    - Normalizes the path
+  - Strips leading slashes (absolute paths)
+  - Removes '..' components
+  - Normalizes the path
 
-    :param filename: The raw filename from the request.
-    :return: Sanitized relative path.
-    """
-    # Remove leading slashes to prevent absolute paths
-    filename = filename.lstrip("/")
+  :param filename: The raw filename from the request.
+  :return: Sanitized relative path.
+  """
+  # Remove leading slashes to prevent absolute paths
+  filename = filename.lstrip("/")
 
-    # Split into parts and filter out dangerous components
-    parts = Path(filename).parts
-    safe_parts = [p for p in parts if p not in ("..", ".")]
+  # Split into parts and filter out dangerous components
+  parts = Path(filename).parts
+  safe_parts = [p for p in parts if p not in ("..", ".")]
 
-    if not safe_parts:
-        return ""
+  if not safe_parts:
+    return ""
 
-    return str(Path(*safe_parts))
+  return str(Path(*safe_parts))
 
 
 @dataclass
 class Blob:
-    """In-memory data with explicit content-type.
+  """In-memory data with explicit content-type.
 
-    Use one of: data (bytes), text (str), or json (dict/list)::
+  Use one of: data (bytes), text (str), or json (dict/list)::
 
-        return Blob(data=raw_bytes)
-        return Blob(text="<xml>...</xml>", content_type="application/xml")
-        return Blob(json={"status": "ok"})
-    """
-    data: bytes = None
-    text: str = None
-    json: Union[dict, list] = None
-    content_type: str = None
+      return Blob(data=raw_bytes)
+      return Blob(text="<xml>...</xml>", content_type="application/xml")
+      return Blob(json={"status": "ok"})
+  """
 
-    def __post_init__(self):
-        # Validate exactly one content field is set
-        fields = [self.data, self.text, self.json]
-        set_count = sum(1 for f in fields if f is not None)
-        if set_count != 1:
-            raise ValueError("Exactly one of data, text, or json must be set")
+  data: bytes = None
+  text: str = None
+  json: Union[dict, list] = None
+  content_type: str = None
 
-        # Set default content-type based on field used
-        if self.content_type is None:
-            if self.json is not None:
-                self.content_type = "application/json"
-            elif self.text is not None:
-                self.content_type = "text/plain"
-            else:
-                self.content_type = "application/octet-stream"
+  def __post_init__(self):
+    # Validate exactly one content field is set
+    fields = [self.data, self.text, self.json]
+    set_count = sum(1 for f in fields if f is not None)
+    if set_count != 1:
+      raise ValueError("Exactly one of data, text, or json must be set")
 
-    def as_bytes(self) -> bytes:
-        """Convert content to bytes."""
-        if self.data is not None:
-            return self.data
-        if self.text is not None:
-            return self.text.encode("utf-8")
-        if self.json is not None:
-            return json.dumps(self.json).encode("utf-8")
+    # Set default content-type based on field used
+    if self.content_type is None:
+      if self.json is not None:
+        self.content_type = "application/json"
+      elif self.text is not None:
+        self.content_type = "text/plain"
+      else:
+        self.content_type = "application/octet-stream"
+
+  def as_bytes(self) -> bytes:
+    """Convert content to bytes."""
+    if self.data is not None:
+      return self.data
+    if self.text is not None:
+      return self.text.encode("utf-8")
+    if self.json is not None:
+      return json.dumps(self.json).encode("utf-8")
 
 
 # Type alias for resolve() return type
@@ -182,462 +185,465 @@ ResolveResult = Union[Path, bytes, Blob, AsyncIterator[bytes], None]
 
 
 class Workspace:
-    """Workspace defines search paths for static file serving.
-
-    A Workspace manages multiple search paths (overlay) for serving static files,
-    similar to how $PATH works for executables. When a file is requested, paths
-    are searched in order and the first match wins.
-
-    This is useful when assets are spread across multiple directories::
-
-        # Robot models in one place, textures in another
-        workspace = Workspace("./local_assets", "/shared/robots", "/data/textures")
-
-        # Request for /static/robot.urdf searches:
-        #   1. ./local_assets/robot.urdf
-        #   2. /shared/robots/robot.urdf
-        #   3. /data/textures/robot.urdf
-        # Returns first match
-
-    **API**::
-
-        workspace = Workspace(*overlay)       # Define search paths
-        workspace.paths                       # Access paths (read-only tuple)
-        workspace.find("file.txt")            # Find file in overlay
-        workspace.mount("./dir", to="/route") # Mount single directory
-        workspace.link(fn, to="/api")         # Link callable to URL path
-
-    Attributes:
-        paths: Tuple of paths that form the search overlay.
-        MIME_TYPES: MimeTypes dict for content-type lookup (class attribute).
-    """
-
-    # Class-level MIME types with guess() method.
-    # Add custom types: Workspace.MIME_TYPES[".npy"] = "application/x-npy"
-    # Guess type: Workspace.MIME_TYPES.guess("file.npy")
-    MIME_TYPES = MIME_TYPES
-
-    def __init__(self, *overlay: Union[str, Path]):
-        """Initialize the Workspace with overlay paths.
-
-        :param overlay: Variable number of paths to search for static files.
-                       Earlier paths take precedence (like $PATH).
-                       If no paths provided, defaults to current directory ".".
-
-        Example::
-
-            # Single path
-            workspace = Workspace("./assets")
-
-            # Multiple paths - first match wins
-            workspace = Workspace("./local", "/shared", "/data")
-
-            # No args = current directory
-            workspace = Workspace()
-
-            # Add custom MIME types (class-level, affects all instances)
-            Workspace.MIME_TYPES[".npy"] = "application/x-npy"
-        """
-        if not overlay:
-            overlay = (".",)
-
-        self._overlay: tuple[Path, ...] = tuple(Path(p) for p in overlay)
-        self._mounts: List[dict] = []  # Directory mounts
-        self._links: dict[str, dict] = {}  # Dynamic links keyed by path
-
-    @property
-    def paths(self) -> tuple[Path, ...]:
-        """The overlay paths (read-only).
-
-        :return: Tuple of Path objects representing the search paths.
-        """
-        return self._overlay
-
-    @property
-    def absolute_paths(self) -> List[str]:
-        """Get absolute paths as strings for display.
-
-        :return: List of absolute path strings.
-        """
-        return [os.path.abspath(p) for p in self._overlay]
-
-    def find(self, filename: str) -> Optional[Path]:
-        """Find a file in the overlay paths (sync version).
-
-        Searches through paths in order and returns the first match.
-        For async code, use :meth:`resolve` instead.
-
-        Path traversal attacks are prevented by sanitizing the filename.
-
-        :param filename: The filename (relative path) to search for.
-        :return: Path to the file if found, None otherwise.
-
-        Example::
-
-            workspace = Workspace("./assets", "/data")
-            path = workspace.find("models/robot.urdf")
-            if path:
-                print(f"Found at: {path}")
-        """
-        # Sanitize to prevent path traversal
-        filename = sanitize_path(filename)
-        if not filename:
-            return None
-
-        for root in self._overlay:
-            filepath = root / filename
-            if filepath.is_file():
-                return filepath
-        return None
-
-    async def exists(self, filepath: Path) -> bool:
-        """Check if a file exists at the given path.
-
-        Override this method for remote backends that need async existence checks.
-
-        :param filepath: Full path to check.
-        :return: True if file exists, False otherwise.
-
-        Example subclass for S3::
-
-            class S3Workspace(Workspace):
-                async def exists(self, filepath: Path) -> bool:
-                    return await self.s3.head_object(str(filepath))
-        """
-        return filepath.is_file()
-
-    async def resolve(self, filename: str) -> ResolveResult:
-        """Resolve a filename by searching through overlay layers.
-
-        Searches each layer in order, returning the first match.
-        Override this method or :meth:`exists` for different storage backends.
-
-        :param filename: The filename (relative path) to resolve.
-        :return: Path, bytes, Blob, AsyncIterator, or None if not found.
-
-        Example subclasses::
-
-            class S3Workspace(Workspace):
-                async def resolve(self, filename: str) -> ResolveResult:
-                    stream = await self.s3.get_object_stream(filename)
-                    return stream  # AsyncIterator[bytes]
-
-            class CachedWorkspace(Workspace):
-                async def resolve(self, filename: str) -> ResolveResult:
-                    if filename in self.cache:
-                        return self.cache[filename]  # bytes
-                    return await super().resolve(filename)
-
-            class ApiWorkspace(Workspace):
-                async def resolve(self, filename: str) -> ResolveResult:
-                    data = await self.fetch_json(filename)
-                    return Blob(json.dumps(data).encode(), "application/json")
-        """
-        # Sanitize to prevent path traversal
-        filename = sanitize_path(filename)
-        if not filename:
-            return None
-
-        for root in self._overlay:
-            filepath = root / filename
-            if await self.exists(filepath):
-                return filepath
-        return None
-
-    def mount(self, path: Union[str, Path], *, to: str):
-        """Mount a directory at a URL route.
-
-        This registers a route configuration that will be applied when
-        the workspace is bound to a server.
-
-        :param path: The local directory path to mount.
-        :param to: The URL route prefix (keyword-only).
-
-        Example::
-
-            workspace = Workspace("./assets")
-            workspace.mount("./uploads", to="/uploads")
-            workspace.mount("/var/exports", to="/exports")
-        """
-        root = Path(path)
-
-        async def handler(request):
-            filename = request.match_info["filename"]
-            filepath = root / filename
-
-            if not filepath.is_file():
-                raise web.HTTPNotFound()
-
-            response = web.FileResponse(filepath)
-
-            # Handle hot reload header
-            hot_key = None
-            for key in request.query.keys():
-                if key.lower() == "hot":
-                    hot_key = key
-                    break
-
-            if hot_key:
-                hot_value = request.query.get(hot_key, "")
-                if hot_value.lower() != "false":
-                    response.headers["Cache-Control"] = "no-cache"
-
-            return response
-
-        self._mounts.append({
-            "type": "mount",
-            "path": to,
-            "handler": handler,
-        })
-
-    def link(
-        self,
-        target: Union[Callable, Path, bytes],
-        to: str,
-        *,
-        method: str = "GET",
-        content_type: str = None,
-    ):
-        """Link a Path, bytes, or callable to a URL path (dynamic, works at runtime).
-
-        Links are stored in a dict and looked up at request time, so you can
-        add/remove links while the server is running.
-
-        - **Path**: Served directly as a static file (efficient streaming)
-        - **bytes**: Served directly as binary data
-        - **Callable**: Called on each request, return type determines response
-
-        Callable return types are handled automatically:
-
-        - ``dict``/``list``: JSON response
-        - ``Path``: File response (efficient streaming)
-        - ``bytes``: Binary response (content-type from path extension)
-        - ``Blob``: Binary response with explicit content-type
-        - ``str``: Text response
-
-        :param target: Path, bytes, or handler function.
-                      Functions can optionally receive request, sync or async.
-        :param to: The URL path for this handler.
-        :param method: HTTP method (default: "GET").
-        :param content_type: Response content type. If None, auto-detected
-                            from path extension.
-
-        Example::
-
-            from pathlib import Path
-            from vuer import Vuer
-            from vuer.workspace import jpg
-
-            vuer = Vuer()
-
-            # Static file link (alias to a different path)
-            vuer.workspace.link(Path("./robots/panda.urdf"), "/robot.urdf")
-
-            # Dynamic image from camera
-            vuer.workspace.link(lambda: jpg(camera.frame), "/live/frame.jpg")
-
-            # Serve file bytes directly
-            vuer.workspace.link(lambda: Path("./scene.xml").read_bytes(), "/scene.xml")
-
-            # Dynamic file selection via query params
-            vuer.workspace.link(
-                lambda r: Path(f"./robots/{r.query.get('model', 'panda')}.urdf"),
-                "/robot.urdf"
-            )
-
-            # JSON response
-            vuer.workspace.link(lambda: {"status": "ok"}, "/api/status")
-
-            # Remove a link later
-            vuer.workspace.unlink("/api/status")
-
-        .. note:: Lambda Capture
-
-            Lambdas capture variables by reference, not value. In loops, use
-            default arguments to capture the current value::
-
-                # WRONG - all lambdas return the final value of i
-                for i in range(3):
-                    workspace.link(lambda: f"value {i}", f"/api/{i}")
-
-                # CORRECT - each lambda captures its own i
-                for i in range(3):
-                    workspace.link(lambda i=i: f"value {i}", f"/api/{i}")
-        """
-        # Normalize path (ensure leading slash, no trailing slash)
-        path = "/" + to.strip("/")
-
-        # Auto-detect content-type from path extension if not specified
-        effective_content_type = content_type or self.MIME_TYPES.guess(to)
-
-        # Handle Path, bytes, or callable
-        if isinstance(target, Path):
-            # Static file link
-            file_path = target.resolve()
-            self._links[path] = {
-                "type": "file",
-                "path": file_path,
-                "method": method,
-                "content_type": effective_content_type,
-            }
-        elif isinstance(target, bytes):
-            # Static bytes link
-            self._links[path] = {
-                "type": "bytes",
-                "data": target,
-                "method": method,
-                "content_type": effective_content_type,
-            }
-        else:
-            # Callable link
-            sig = inspect.signature(target)
-            takes_request = len(sig.parameters) > 0
-            self._links[path] = {
-                "type": "callable",
-                "fn": target,
-                "method": method,
-                "content_type": effective_content_type,
-                "takes_request": takes_request,
-            }
-
-    def unlink(self, path: str) -> bool:
-        """Remove a linked callable from a URL path.
-
-        :param path: The URL path to unlink.
-        :return: True if the link was removed, False if it didn't exist.
-
-        Example::
-
-            workspace.link(lambda: {"status": "ok"}, "/api/status")
-            # ... later ...
-            workspace.unlink("/api/status")
-        """
-        # Normalize path
-        path = "/" + path.strip("/")
-        if path in self._links:
-            del self._links[path]
-            return True
-        return False
-
-    async def handle_link(self, path: str, request) -> Optional[web.Response]:
-        """Handle a request for a linked path (called by server).
-
-        :param path: The normalized URL path.
-        :param request: The aiohttp request object.
-        :return: Response if path is linked, None otherwise.
-        """
-        # Normalize path
-        path = "/" + path.strip("/")
-
-        link = self._links.get(path)
-        if link is None:
-            return None
-
-        content_type = link["content_type"]
-
-        # Handle file links (static)
-        if link.get("type") == "file":
-            file_path = link["path"]
-            if not file_path.is_file():
-                return web.Response(status=404, text=f"File not found: {file_path}")
-            response = web.FileResponse(file_path)
-            response.content_type = content_type or self.MIME_TYPES.guess(file_path.name)
-            return response
-
-        # Handle bytes links (static)
-        if link.get("type") == "bytes":
-            return web.Response(body=link["data"], content_type=content_type)
-
-        # Handle callable links (dynamic)
-        fn = link["fn"]
-        takes_request = link.get("takes_request", False)
-
-        try:
-            # Call with or without request based on signature
-            if asyncio.iscoroutinefunction(fn):
-                result = await (fn(request) if takes_request else fn())
-            else:
-                result = fn(request) if takes_request else fn()
-
-            # Handle different return types
-            if isinstance(result, (dict, list)):
-                return web.Response(
-                    text=json.dumps(result),
-                    content_type="application/json",
-                )
-            if isinstance(result, Path):
-                if not result.is_file():
-                    return web.Response(status=404, text=f"File not found: {result}")
-                response = web.FileResponse(result)
-                response.content_type = content_type or self.MIME_TYPES.guess(result.name)
-                return response
-            if isinstance(result, Blob):
-                return web.Response(
-                    body=result.as_bytes(),
-                    content_type=result.content_type,
-                )
-            if isinstance(result, bytes):
-                return web.Response(
-                    body=result,
-                    content_type=content_type,
-                )
-            return web.Response(text=str(result), content_type=content_type)
-        except Exception as e:
-            return web.Response(status=500, text=str(e))
-
-    @property
-    def links(self) -> dict[str, dict]:
-        """Get registered links (read-only view).
-
-        :return: Dict of path -> link config.
-        """
-        return self._links
-
-    @property
-    def mounts(self) -> List[dict]:
-        """Get registered mounts for the server to apply.
-
-        Returns a list of mount configurations that the server should
-        register when starting up.
-
-        :return: List of mount configuration dicts with path, handler, method.
-        """
-        return self._mounts
-
-    def __repr__(self):
-        paths_str = ", ".join(f'"{p}"' for p in self._overlay)
-        return f"Workspace({paths_str})"
-
-
-def workspace_from_config(
-    config: Union[str, Path, List[Union[str, Path]], "Workspace", None],
-) -> Workspace:
-    """Convert various workspace configurations to a Workspace instance.
-
-    This handles backwards compatibility with the old workspace parameter
-    that accepted strings, paths, or lists.
-
-    :param config: Workspace configuration. Can be:
-                  - None: returns Workspace() (current directory)
-                  - str or Path: single path
-                  - List of str/Path: multiple paths (overlay)
-                  - Workspace: returned as-is
-    :return: A Workspace instance.
+  """Workspace defines search paths for static file serving.
+
+  A Workspace manages multiple search paths (overlay) for serving static files,
+  similar to how $PATH works for executables. When a file is requested, paths
+  are searched in order and the first match wins.
+
+  This is useful when assets are spread across multiple directories::
+
+      # Robot models in one place, textures in another
+      workspace = Workspace("./local_assets", "/shared/robots", "/data/textures")
+
+      # Request for /static/robot.urdf searches:
+      #   1. ./local_assets/robot.urdf
+      #   2. /shared/robots/robot.urdf
+      #   3. /data/textures/robot.urdf
+      # Returns first match
+
+  **API**::
+
+      workspace = Workspace(*overlay)       # Define search paths
+      workspace.paths                       # Access paths (read-only tuple)
+      workspace.find("file.txt")            # Find file in overlay
+      workspace.mount("./dir", to="/route") # Mount single directory
+      workspace.link(fn, to="/api")         # Link callable to URL path
+
+  Attributes:
+      paths: Tuple of paths that form the search overlay.
+      MIME_TYPES: MimeTypes dict for content-type lookup (class attribute).
+  """
+
+  # Class-level MIME types with guess() method.
+  # Add custom types: Workspace.MIME_TYPES[".npy"] = "application/x-npy"
+  # Guess type: Workspace.MIME_TYPES.guess("file.npy")
+  MIME_TYPES = MIME_TYPES
+
+  def __init__(self, *overlay: Union[str, Path]):
+    """Initialize the Workspace with overlay paths.
+
+    :param overlay: Variable number of paths to search for static files.
+                   Earlier paths take precedence (like $PATH).
+                   If no paths provided, defaults to current directory ".".
 
     Example::
 
-        # All of these work:
-        ws = workspace_from_config(None)           # Workspace(".")
-        ws = workspace_from_config("./assets")     # Workspace("./assets")
-        ws = workspace_from_config(["./a", "./b"]) # Workspace("./a", "./b")
-        ws = workspace_from_config(existing_ws)    # returns existing_ws
+        # Single path
+        workspace = Workspace("./assets")
+
+        # Multiple paths - first match wins
+        workspace = Workspace("./local", "/shared", "/data")
+
+        # No args = current directory
+        workspace = Workspace()
+
+        # Add custom MIME types (class-level, affects all instances)
+        Workspace.MIME_TYPES[".npy"] = "application/x-npy"
     """
-    if config is None:
-        return Workspace()
-    if isinstance(config, Workspace):
-        return config
-    if isinstance(config, (str, Path)):
-        return Workspace(config)
-    if isinstance(config, list):
-        return Workspace(*config)
-    raise TypeError(f"Cannot convert {type(config)} to Workspace")
+    if not overlay:
+      overlay = (".",)
+
+    self._overlay: tuple[Path, ...] = tuple(Path(p) for p in overlay)
+    self._mounts: List[dict] = []  # Directory mounts
+    self._links: dict[str, dict] = {}  # Dynamic links keyed by path
+
+  @property
+  def paths(self) -> tuple[Path, ...]:
+    """The overlay paths (read-only).
+
+    :return: Tuple of Path objects representing the search paths.
+    """
+    return self._overlay
+
+  @property
+  def absolute_paths(self) -> List[str]:
+    """Get absolute paths as strings for display.
+
+    :return: List of absolute path strings.
+    """
+    return [os.path.abspath(p) for p in self._overlay]
+
+  def find(self, filename: str) -> Optional[Path]:
+    """Find a file in the overlay paths (sync version).
+
+    Searches through paths in order and returns the first match.
+    For async code, use :meth:`resolve` instead.
+
+    Path traversal attacks are prevented by sanitizing the filename.
+
+    :param filename: The filename (relative path) to search for.
+    :return: Path to the file if found, None otherwise.
+
+    Example::
+
+        workspace = Workspace("./assets", "/data")
+        path = workspace.find("models/robot.urdf")
+        if path:
+            print(f"Found at: {path}")
+    """
+    # Sanitize to prevent path traversal
+    filename = sanitize_path(filename)
+    if not filename:
+      return None
+
+    for root in self._overlay:
+      filepath = root / filename
+      if filepath.is_file():
+        return filepath
+    return None
+
+  async def exists(self, filepath: Path) -> bool:
+    """Check if a file exists at the given path.
+
+    Override this method for remote backends that need async existence checks.
+
+    :param filepath: Full path to check.
+    :return: True if file exists, False otherwise.
+
+    Example subclass for S3::
+
+        class S3Workspace(Workspace):
+            async def exists(self, filepath: Path) -> bool:
+                return await self.s3.head_object(str(filepath))
+    """
+    return filepath.is_file()
+
+  async def resolve(self, filename: str) -> ResolveResult:
+    """Resolve a filename by searching through overlay layers.
+
+    Searches each layer in order, returning the first match.
+    Override this method or :meth:`exists` for different storage backends.
+
+    :param filename: The filename (relative path) to resolve.
+    :return: Path, bytes, Blob, AsyncIterator, or None if not found.
+
+    Example subclasses::
+
+        class S3Workspace(Workspace):
+            async def resolve(self, filename: str) -> ResolveResult:
+                stream = await self.s3.get_object_stream(filename)
+                return stream  # AsyncIterator[bytes]
+
+        class CachedWorkspace(Workspace):
+            async def resolve(self, filename: str) -> ResolveResult:
+                if filename in self.cache:
+                    return self.cache[filename]  # bytes
+                return await super().resolve(filename)
+
+        class ApiWorkspace(Workspace):
+            async def resolve(self, filename: str) -> ResolveResult:
+                data = await self.fetch_json(filename)
+                return Blob(json.dumps(data).encode(), "application/json")
+    """
+    # Sanitize to prevent path traversal
+    filename = sanitize_path(filename)
+    if not filename:
+      return None
+
+    for root in self._overlay:
+      filepath = root / filename
+      if await self.exists(filepath):
+        return filepath
+    return None
+
+  def mount(self, path: Union[str, Path], *, to: str):
+    """Mount a directory at a URL route.
+
+    This registers a route configuration that will be applied when
+    the workspace is bound to a server.
+
+    :param path: The local directory path to mount.
+    :param to: The URL route prefix (keyword-only).
+
+    Example::
+
+        workspace = Workspace("./assets")
+        workspace.mount("./uploads", to="/uploads")
+        workspace.mount("/var/exports", to="/exports")
+    """
+    root = Path(path)
+
+    async def handler(request):
+      filename = request.match_info["filename"]
+      filepath = root / filename
+
+      if not filepath.is_file():
+        raise web.HTTPNotFound()
+
+      response = web.FileResponse(filepath)
+
+      # Handle hot reload header
+      hot_key = None
+      for key in request.query.keys():
+        if key.lower() == "hot":
+          hot_key = key
+          break
+
+      if hot_key:
+        hot_value = request.query.get(hot_key, "")
+        if hot_value.lower() != "false":
+          response.headers["Cache-Control"] = "no-cache"
+
+      return response
+
+    self._mounts.append(
+      {
+        "type": "mount",
+        "path": to,
+        "handler": handler,
+      }
+    )
+
+  def link(
+    self,
+    target: Union[Callable, Path, bytes],
+    to: str,
+    *,
+    method: str = "GET",
+    content_type: str = None,
+  ) -> str:
+    """Link a Path, bytes, or callable to a URL path (dynamic, works at runtime).
+
+    Links are stored in a dict and looked up at request time, so you can
+    add/remove links while the server is running.
+
+    - **Path**: Served directly as a static file (efficient streaming)
+    - **bytes**: Served directly as binary data
+    - **Callable**: Called on each request, return type determines response
+
+    Callable return types are handled automatically:
+
+    - ``dict``/``list``: JSON response
+    - ``Path``: File response (efficient streaming)
+    - ``bytes``: Binary response (content-type from path extension)
+    - ``Blob``: Binary response with explicit content-type
+    - ``str``: Text response
+
+    :param target: Path, bytes, or handler function.
+                  Functions can optionally receive request, sync or async.
+    :param to: The URL path for this handler.
+    :param method: HTTP method (default: "GET").
+    :param content_type: Response content type. If None, auto-detected
+                        from path extension.
+
+    Example::
+
+        from pathlib import Path
+        from vuer import Vuer
+        from vuer.workspace import jpg
+
+        vuer = Vuer()
+
+        # Static file link (alias to a different path)
+        vuer.workspace.link(Path("./robots/panda.urdf"), "/robot.urdf")
+
+        # Dynamic image from camera
+        vuer.workspace.link(lambda: jpg(camera.frame), "/live/frame.jpg")
+
+        # Serve file bytes directly
+        vuer.workspace.link(lambda: Path("./scene.xml").read_bytes(), "/scene.xml")
+
+        # Dynamic file selection via query params
+        vuer.workspace.link(
+            lambda r: Path(f"./robots/{r.query.get('model', 'panda')}.urdf"),
+            "/robot.urdf"
+        )
+
+        # JSON response
+        vuer.workspace.link(lambda: {"status": "ok"}, "/api/status")
+
+        # Remove a link later
+        vuer.workspace.unlink("/api/status")
+
+    .. note:: Lambda Capture
+
+        Lambdas capture variables by reference, not value. In loops, use
+        default arguments to capture the current value::
+
+            # WRONG - all lambdas return the final value of i
+            for i in range(3):
+                workspace.link(lambda: f"value {i}", f"/api/{i}")
+
+            # CORRECT - each lambda captures its own i
+            for i in range(3):
+                workspace.link(lambda i=i: f"value {i}", f"/api/{i}")
+    """
+    # Normalize path (ensure leading slash, no trailing slash)
+    path = "/" + to.strip("/")
+
+    # Auto-detect content-type from path extension if not specified
+    effective_content_type = content_type or self.MIME_TYPES.guess(to)
+
+    # Handle Path, bytes, or callable
+    if isinstance(target, Path):
+      # Static file link
+      file_path = target.resolve()
+      self._links[path] = {
+        "type": "file",
+        "path": file_path,
+        "method": method,
+        "content_type": effective_content_type,
+      }
+    elif isinstance(target, bytes):
+      # Static bytes link
+      self._links[path] = {
+        "type": "bytes",
+        "data": target,
+        "method": method,
+        "content_type": effective_content_type,
+      }
+    else:
+      # Callable link
+      sig = inspect.signature(target)
+      takes_request = len(sig.parameters) > 0
+      self._links[path] = {
+        "type": "callable",
+        "fn": target,
+        "method": method,
+        "content_type": effective_content_type,
+        "takes_request": takes_request,
+      }
+    return to
+
+  def unlink(self, path: str) -> bool:
+    """Remove a linked callable from a URL path.
+
+    :param path: The URL path to unlink.
+    :return: True if the link was removed, False if it didn't exist.
+
+    Example::
+
+        workspace.link(lambda: {"status": "ok"}, "/api/status")
+        # ... later ...
+        workspace.unlink("/api/status")
+    """
+    # Normalize path
+    path = "/" + path.strip("/")
+    if path in self._links:
+      del self._links[path]
+      return True
+    return False
+
+  async def handle_link(self, path: str, request) -> Optional[web.Response]:
+    """Handle a request for a linked path (called by server).
+
+    :param path: The normalized URL path.
+    :param request: The aiohttp request object.
+    :return: Response if path is linked, None otherwise.
+    """
+    # Normalize path
+    path = "/" + path.strip("/")
+
+    link = self._links.get(path)
+    if link is None:
+      return None
+
+    content_type = link["content_type"]
+
+    # Handle file links (static)
+    if link.get("type") == "file":
+      file_path = link["path"]
+      if not file_path.is_file():
+        return web.Response(status=404, text=f"File not found: {file_path}")
+      response = web.FileResponse(file_path)
+      response.content_type = content_type or self.MIME_TYPES.guess(file_path.name)
+      return response
+
+    # Handle bytes links (static)
+    if link.get("type") == "bytes":
+      return web.Response(body=link["data"], content_type=content_type)
+
+    # Handle callable links (dynamic)
+    fn = link["fn"]
+    takes_request = link.get("takes_request", False)
+
+    try:
+      # Call with or without request based on signature
+      if asyncio.iscoroutinefunction(fn):
+        result = await (fn(request) if takes_request else fn())
+      else:
+        result = fn(request) if takes_request else fn()
+
+      # Handle different return types
+      if isinstance(result, (dict, list)):
+        return web.Response(
+          text=json.dumps(result),
+          content_type="application/json",
+        )
+      if isinstance(result, Path):
+        if not result.is_file():
+          return web.Response(status=404, text=f"File not found: {result}")
+        response = web.FileResponse(result)
+        response.content_type = content_type or self.MIME_TYPES.guess(result.name)
+        return response
+      if isinstance(result, Blob):
+        return web.Response(
+          body=result.as_bytes(),
+          content_type=result.content_type,
+        )
+      if isinstance(result, bytes):
+        return web.Response(
+          body=result,
+          content_type=content_type,
+        )
+      return web.Response(text=str(result), content_type=content_type)
+    except Exception as e:
+      return web.Response(status=500, text=str(e))
+
+  @property
+  def links(self) -> dict[str, dict]:
+    """Get registered links (read-only view).
+
+    :return: Dict of path -> link config.
+    """
+    return self._links
+
+  @property
+  def mounts(self) -> List[dict]:
+    """Get registered mounts for the server to apply.
+
+    Returns a list of mount configurations that the server should
+    register when starting up.
+
+    :return: List of mount configuration dicts with path, handler, method.
+    """
+    return self._mounts
+
+  def __repr__(self):
+    paths_str = ", ".join(f'"{p}"' for p in self._overlay)
+    return f"Workspace({paths_str})"
+
+
+def workspace_from_config(
+  config: Union[str, Path, List[Union[str, Path]], "Workspace", None],
+) -> Workspace:
+  """Convert various workspace configurations to a Workspace instance.
+
+  This handles backwards compatibility with the old workspace parameter
+  that accepted strings, paths, or lists.
+
+  :param config: Workspace configuration. Can be:
+                - None: returns Workspace() (current directory)
+                - str or Path: single path
+                - List of str/Path: multiple paths (overlay)
+                - Workspace: returned as-is
+  :return: A Workspace instance.
+
+  Example::
+
+      # All of these work:
+      ws = workspace_from_config(None)           # Workspace(".")
+      ws = workspace_from_config("./assets")     # Workspace("./assets")
+      ws = workspace_from_config(["./a", "./b"]) # Workspace("./a", "./b")
+      ws = workspace_from_config(existing_ws)    # returns existing_ws
+  """
+  if config is None:
+    return Workspace()
+  if isinstance(config, Workspace):
+    return config
+  if isinstance(config, (str, Path)):
+    return Workspace(config)
+  if isinstance(config, list):
+    return Workspace(*config)
+  raise TypeError(f"Cannot convert {type(config)} to Workspace")


### PR DESCRIPTION
## Summary
- Add task lifecycle management to prevent orphaned coroutines when WebSocket clients disconnect
- Tasks spawned via `_add_task` can now be associated with a `ws_id` and are automatically cancelled on websocket close
- Fix Scene serialization to omit empty `bgChildren`, `rawChildren`, and `htmlChildren` arrays
- Standardize 2-space indentation in `scene_store.py` and `workspace.py`

## Test plan
- [ ] Verify tasks are properly cancelled when client disconnects
- [ ] Confirm Scene serialization no longer includes empty children arrays
- [ ] Run existing tests to ensure no regressions