### PR TITLE
feat(client): add ssl_verify flag for VuerClient

### DIFF
--- a/docs/guides/client_connection.md
+++ b/docs/guides/client_connection.md
@@ -101,15 +101,19 @@ from vuer import VuerClient
 client = VuerClient()
 
 # Custom URI
-client = VuerClient(URI="ws://192.168.1.100:8012")
+client = VuerClient(uri="ws://192.168.1.100:8012")
 
 # With custom max message size (default 256MB)
-client = VuerClient(URI="ws://localhost:8012", WEBSOCKET_MAX_SIZE=2**30)
+client = VuerClient(uri="ws://localhost:8012", max_size=2**30)
+
+# Disable SSL certificate verification (e.g., for ngrok with self-signed certs)
+client = VuerClient(uri="wss://7.tcp.ngrok.io:26620", ssl_verify=False)
 ```
 
 Configuration can also be set via environment variables:
 - `VUER_CLIENT_URI`: WebSocket URI (default `ws://localhost:8012`)
 - `WEBSOCKET_MAX_SIZE`: Maximum message size in bytes (default 256MB)
+- `VUER_SSL_VERIFY`: Whether to verify SSL certificates (default `true`)
 
 ### Context Manager (Recommended)
 
@@ -271,4 +275,6 @@ Run the server first, then run the client in a separate terminal to see the anim
 - Use `await client.send(Event())` when you need to wait for the send to complete
 - Use `client.connected` to check connection status
 - Reconnect by calling `connect()` again if disconnected
-- Configure via environment variables: `VUER_CLIENT_URI`, `WEBSOCKET_MAX_SIZE`
+- Configure via environment variables: `VUER_CLIENT_URI`, `WEBSOCKET_MAX_SIZE`, `VUER_SSL_VERIFY`
+- Use `ssl_verify=False` when connecting through tunnels with self-signed certificates (e.g., ngrok TCP tunnels)
+- You can also pass any `websockets.connect()` kwargs (e.g., a custom `ssl=` context) through the constructor

--- a/docs/tutorials/basics/ngrok_setup.md
+++ b/docs/tutorials/basics/ngrok_setup.md
@@ -101,3 +101,19 @@ https://vuer.ai/?ws=wss://YOUR_USERNAME-vuer-port.ap.ngrok.io
 ngrok http --subdomain=YOUR_USERNAME-vuer-port 3012
 ```
 The connection URL remains the same since you're using a custom subdomain.
+
+## Connecting a Python Client via ngrok
+
+When connecting a `VuerClient` to a Vuer server through ngrok (especially TCP tunnels), you may encounter SSL certificate verification errors with self-signed certificates. Use `ssl_verify=False` to disable verification:
+
+```python
+from vuer import VuerClient
+
+async with VuerClient(uri="wss://7.tcp.ngrok.io:26620", ssl_verify=False) as client:
+    ...
+```
+
+Or set the environment variable:
+```bash
+VUER_SSL_VERIFY=false python client.py
+```


### PR DESCRIPTION
## Summary
- Add `ssl_verify` param and `VUER_SSL_VERIFY` env var to `VuerClient` for disabling SSL cert verification (e.g., ngrok TCP tunnels with self-signed certs)
- Forward `**kwargs` from constructor to `websockets.connect()` for full control (e.g., custom `ssl.SSLContext`)
- Update client connection guide and ngrok setup docs

## Usage
```python
# Simple flag
async with VuerClient(uri="wss://7.tcp.ngrok.io:26620", ssl_verify=False) as client:
    ...

# Or env var
# VUER_SSL_VERIFY=false python client.py

# Or custom ssl context
async with VuerClient(uri="wss://...", ssl=my_ssl_ctx) as client:
    ...
```

Closes #153

## Test plan
- [x] Existing tests pass (`pytest src/vuer/__tests__/test_client.py`)
- [ ] Manual test: connect to ngrok wss:// endpoint with `ssl_verify=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)