### PR TITLE
docs: Add sphinx-design extension from vuer-doc-boilerplate

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.11"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     "myst_parser",
     "sphinx_copybutton",
     "sphinxcontrib.video",
+    "sphinx_design",
 ]
 
 video_enforce_extra_source = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "sphinx_copybutton",
     "sphinxcontrib-video>=0.4.1",
     "myst_parser",
+    "sphinx-design",
     # these are very optional but needed for the doc site
     "trimesh",
     "tqdm",


### PR DESCRIPTION
## Summary

This PR aligns the vuer documentation setup with the [vuer-doc-boilerplate](https://github.com/vuer-ai/vuer-doc-boilerplate) standard by:

- Adding the `sphinx-design` extension to enable enhanced documentation layouts (cards, grids, tabs, dropdowns)
- Updating the ReadTheDocs Python version from 3.8 to 3.11 for better compatibility
- Adding `sphinx-design` to the `dev` dependencies in `pyproject.toml`

## Changes

1. **docs/conf.py**: Added `sphinx_design` to the extensions list
2. **pyproject.toml**: Added `sphinx-design` to dev dependencies
3. **.readthedocs.yaml**: Updated Python version from 3.8 to 3.11

## Benefits

The `sphinx-design` extension provides modern UI components that enhance documentation readability and organization. This brings vuer's documentation tooling in line with the standard used across other vuer-ai repositories.

## Testing

The existing `make preview` and `make docs` commands continue to work as expected.

## Note

The Makefile already has the required `make preview` and `make docs` commands, so no changes were needed there.