### PR TITLE
feat: add WebRTC video streaming support

### DIFF
--- a/docs/examples/webrtc/custom_track.py
+++ b/docs/examples/webrtc/custom_track.py
@@ -1,0 +1,50 @@
+"""
+WebRTC Custom Track Example
+============================
+
+Low-level API: bind a custom MediaStreamTrack to a WebRTC stream.
+
+This example uses aiortc's MediaPlayer to stream from a system camera
+or a test video file. The track produces frames on its own — no
+push_frame() needed.
+
+Usage::
+
+    pip install 'vuer[webrtc]'
+    python custom_track.py
+"""
+
+from vuer import Vuer
+from vuer.schemas import WebRTCVideoPlane
+
+# You need aiortc for this example
+from aiortc.contrib.media import MediaPlayer
+
+app = Vuer(host="0.0.0.0", port=8012, free_port=True)
+
+# Open a system camera (macOS: "default:none", Linux: "/dev/video0")
+# Or use a video file: MediaPlayer("/path/to/video.mp4")
+player = MediaPlayer("default:none", format="avfoundation", options={"framerate": "30"})
+
+# Bind the player's video track directly to a stream.
+stream = app.create_webrtc_stream("usb-camera", track=player.video)
+
+# Ensure camera is released on shutdown
+async def _close_player(app):
+    player.video.stop()
+
+app.app.on_shutdown.append(_close_player)
+
+
+@app.spawn(start=True)
+async def main(session):
+    session.upsert(
+        WebRTCVideoPlane(
+            src=stream.endpoint,
+            key="camera-video",
+            distanceToCamera=10,
+            height=3,
+            aspect=4/3,
+        ),
+    )
+    await session.forever()

--- a/docs/examples/webrtc/push_frame.py
+++ b/docs/examples/webrtc/push_frame.py
@@ -1,0 +1,70 @@
+"""
+WebRTC Push Frame Example
+=========================
+
+High-level API: push BGR numpy arrays to a WebRTC stream.
+
+The stream is hosted on Vuer's built-in server — no separate process needed.
+Open the Vuer client URL in a browser to see the video.
+
+Usage::
+
+    pip install 'vuer[webrtc]'
+    python push_frame.py
+"""
+
+import threading
+import time
+import numpy as np
+from vuer import Vuer
+from vuer.schemas import WebRTCVideoPlane
+
+app = Vuer(host="0.0.0.0", port=8012, free_port=True)
+
+# Create a stream before app.start() — route gets registered automatically.
+stream = app.create_webrtc_stream("test")
+
+
+def push_loop():
+    """Generate test pattern frames and push them to the stream (runs in a thread)."""
+    stream.wait_ready_sync()
+
+    W, H = 640, 480
+    BLOCK = 80
+    colors = [
+        (180, 60, 60), (60, 180, 60), (60, 60, 180),
+        (180, 180, 60), (60, 180, 180), (180, 60, 180),
+    ]
+    i = 0
+    while True:
+        frame = np.zeros((H, W, 3), dtype=np.uint8)
+        offset = i % BLOCK
+        idx = 0
+        for y in range(-BLOCK + offset, H, BLOCK):
+            for x in range(-BLOCK + offset, W, BLOCK):
+                c = colors[idx % len(colors)]
+                y0, y1 = max(0, y), min(H, y + BLOCK)
+                x0, x1 = max(0, x), min(W, x + BLOCK)
+                frame[y0:y1, x0:x1] = c
+                idx += 1
+        stream.push_frame(frame)
+        i += 2
+        time.sleep(1 / 30)
+
+
+# Start push thread BEFORE app.spawn(start=True), which blocks in run_forever().
+threading.Thread(target=push_loop, daemon=True).start()
+
+
+@app.spawn(start=True)
+async def main(session):
+    session.upsert(
+        WebRTCVideoPlane(
+            src=stream.endpoint,
+            key="test-video",
+            distanceToCamera=3,
+            height=3,
+            aspect=4/3,
+        ),
+    )
+    await session.forever()

--- a/docs/examples/webrtc/standalone_server.py
+++ b/docs/examples/webrtc/standalone_server.py
@@ -1,0 +1,161 @@
+"""
+Standalone WebRTC Server (without Vuer)
+=======================================
+
+A minimal standalone aiohttp + aiortc server for reference.
+This is what teleimager's image_server.py does — run a separate
+WebRTC server process/thread.
+
+Use this approach when:
+- You don't need Vuer's scene graph or XR features.
+- You want a standalone video streaming endpoint.
+- You need full control over the aiohttp app.
+
+For the Vuer-integrated approach (recommended), see push_frame.py
+and custom_track.py. The Vuer integration eliminates the need for
+a separate server by hosting WebRTC signaling on Vuer's existing
+aiohttp server.
+
+Usage::
+
+    pip install aiortc av aiohttp
+    python standalone_server.py
+"""
+
+import asyncio
+import fractions
+import json
+import time
+
+import av
+import numpy as np
+from aiohttp import web
+from aiortc import MediaStreamTrack, RTCPeerConnection, RTCSessionDescription
+from aiortc.contrib.media import MediaRelay
+from aiortc.rtcrtpsender import RTCRtpSender
+
+
+class BGRArrayVideoStreamTrack(MediaStreamTrack):
+    kind = "video"
+
+    def __init__(self):
+        super().__init__()
+        self._queue = asyncio.Queue(maxsize=1)
+        self._start_time = None
+        self._pts = 0
+
+    async def recv(self):
+        return await self._queue.get()
+
+    def push_frame(self, bgr_numpy, loop=None):
+        video_frame = av.VideoFrame.from_ndarray(bgr_numpy, format="bgr24")
+        if self._start_time is None:
+            self._start_time = time.time()
+            self._pts = 0
+        else:
+            self._pts = int((time.time() - self._start_time) * 90000)
+        video_frame.pts = self._pts
+        video_frame.time_base = fractions.Fraction(1, 90000)
+
+        target_loop = loop or asyncio.get_event_loop()
+
+        def _put():
+            try:
+                if self._queue.full():
+                    self._queue.get_nowait()
+                self._queue.put_nowait(video_frame)
+            except Exception:
+                pass
+
+        target_loop.call_soon_threadsafe(_put)
+
+
+pcs = set()
+track = BGRArrayVideoStreamTrack()
+relay = MediaRelay()
+
+
+async def offer(request):
+    params = await request.json()
+    desc = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+    pc = RTCPeerConnection()
+    pcs.add(pc)
+
+    relayed = relay.subscribe(track)
+    transceiver = pc.addTransceiver(relayed, direction="sendonly")
+
+    # Prefer H264
+    caps = RTCRtpSender.getCapabilities("video")
+    h264 = [c for c in caps.codecs if c.mimeType == "video/H264"]
+    if h264:
+        transceiver.setCodecPreferences(h264)
+
+    @pc.on("connectionstatechange")
+    async def on_state():
+        if pc.connectionState in ("failed", "closed"):
+            pcs.discard(pc)
+            await pc.close()
+
+    await pc.setRemoteDescription(desc)
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps({"sdp": pc.localDescription.sdp, "type": pc.localDescription.type}),
+    )
+
+
+async def generate_frames():
+    """Push test pattern frames at 30fps — colored blocks that scroll."""
+    loop = asyncio.get_event_loop()
+    W, H = 640, 480
+    BLOCK = 80
+    colors = [
+        (180, 60, 60), (60, 180, 60), (60, 60, 180),
+        (180, 180, 60), (60, 180, 180), (180, 60, 180),
+    ]
+    i = 0
+    while True:
+        frame = np.zeros((H, W, 3), dtype=np.uint8)
+        offset = i % BLOCK
+        idx = 0
+        for y in range(-BLOCK + offset, H, BLOCK):
+            for x in range(-BLOCK + offset, W, BLOCK):
+                c = colors[idx % len(colors)]
+                y0, y1 = max(0, y), min(H, y + BLOCK)
+                x0, x1 = max(0, x), min(W, x + BLOCK)
+                frame[y0:y1, x0:x1] = c
+                idx += 1
+        track.push_frame(frame, loop)
+        i += 2
+        await asyncio.sleep(1 / 30)
+
+
+async def on_startup(app):
+    asyncio.ensure_future(generate_frames())
+
+
+async def on_shutdown(app):
+    coros = [pc.close() for pc in pcs]
+    await asyncio.gather(*coros)
+
+
+if __name__ == "__main__":
+    import aiohttp_cors
+
+    app = web.Application()
+    cors = aiohttp_cors.setup(app, defaults={
+        "*": aiohttp_cors.ResourceOptions(
+            allow_credentials=True,
+            expose_headers="*",
+            allow_headers="*",
+            allow_methods="*",
+        )
+    })
+    resource = app.router.add_resource("/offer")
+    cors.add(resource.add_route("POST", offer))
+    app.on_startup.append(on_startup)
+    app.on_shutdown.append(on_shutdown)
+    web.run_app(app, host="0.0.0.0", port=8013)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ example = [
     "ml_logger",
     "opencv-python"
 ]
+webrtc = [
+    "aiortc>=1.6.0",
+    "av>=10.0.0",
+]
 dev = [
     "cmx",
     "aiohttp>=3.10.5",

--- a/src/vuer/__init__.py
+++ b/src/vuer/__init__.py
@@ -16,11 +16,17 @@ from vuer.client import VuerClient
 #     app.run()
 
 
+try:
+  from vuer.webrtc import WebRTCStream
+except ImportError:
+  WebRTCStream = None
+
 __all__ = [
   "Vuer",
   "VuerSession",
   "VuerClient",
   "Workspace",
   "Blob",
+  "WebRTCStream",
   # "entrypoint",
 ]

--- a/src/vuer/base.py
+++ b/src/vuer/base.py
@@ -212,11 +212,13 @@ class Server:
     self._add_route(f"{path}", _fn, method="GET")
 
   def start(self):
+    self._runner = None
+
     async def init_server():
-      runner = web.AppRunner(self.app)
-      await runner.setup()
+      self._runner = web.AppRunner(self.app)
+      await self._runner.setup()
       if not self.cert:
-        site = web.TCPSite(runner, self.host, self.port)
+        site = web.TCPSite(self._runner, self.host, self.port)
         return await site.start()
 
       ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
@@ -227,7 +229,7 @@ class Server:
       else:
         ssl_context.verify_mode = ssl.CERT_NONE
 
-      site = web.TCPSite(runner, self.host, self.port, ssl_context=ssl_context)
+      site = web.TCPSite(self._runner, self.host, self.port, ssl_context=ssl_context)
       return await site.start()
 
     # Check if there's already a running event loop (e.g., in IPython/Jupyter)
@@ -250,7 +252,21 @@ class Server:
       asyncio.set_event_loop(event_loop)
 
     event_loop.run_until_complete(init_server())
-    event_loop.run_forever()
+
+    try:
+      event_loop.run_forever()
+    except KeyboardInterrupt:
+      pass
+    finally:
+      if self._runner is not None:
+        event_loop.run_until_complete(self._runner.cleanup())
+      # Cancel remaining async tasks to avoid "Task was destroyed" warnings
+      pending = asyncio.all_tasks(event_loop)
+      for task in pending:
+        task.cancel()
+      if pending:
+        event_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+      event_loop.close()
 
 
 if __name__ == "__main__":

--- a/src/vuer/server.py
+++ b/src/vuer/server.py
@@ -1404,12 +1404,15 @@ class Vuer(Server):
 
     self._add_route("/relay", self.relay, method="POST")
 
-    # Register WebRTC routes if any streams were created
+    # Always serve the WebRTC debug page (static HTML, no dependencies)
+    from vuer.webrtc import serve_debug_page
+    self._add_route("/webrtc/debug", serve_debug_page, method="GET")
+
+    # Register WebRTC stream routes if any streams were created
     if self._webrtc_manager is not None:
       self._add_route(
         "/webrtc/offer/{stream_id}", self._webrtc_manager.offer_handler, method="POST"
       )
-      self._add_route("/webrtc/debug", self._webrtc_manager.debug_page_handler, method="GET")
 
       async def _set_webrtc_loop(app):
         self._webrtc_manager.set_loop(asyncio.get_running_loop())

--- a/src/vuer/server.py
+++ b/src/vuer/server.py
@@ -702,6 +702,7 @@ class Vuer(Server):
     # List of spawn handlers with their filters: [{"fn": handler, "filters": {...}}, ...]
     self.spawn_handlers: List[Dict] = []
     self.spawned_coroutines = []
+    self._webrtc_manager = None
 
   @property
   def ssl(self) -> str:
@@ -730,6 +731,48 @@ class Vuer(Server):
       return ip
     except Exception:
       return "127.0.0.1"
+
+  def create_webrtc_stream(
+    self,
+    stream_id,
+    track=None,
+    codec="H264",
+    max_bitrate=None,
+    max_framerate=None,
+    resolution=None,
+  ):
+    """Create a WebRTC stream hosted on this Vuer server.
+
+    Must be called before app.start(). Routes are registered during startup.
+
+    Args:
+        stream_id: Unique identifier for the stream (used in URL path).
+        track: Optional custom MediaStreamTrack. If None, creates an internal
+               track and enables push_frame().
+        codec: Preferred codec ("H264" or "VP8"). Default "H264".
+        max_bitrate: Maximum bitrate in bps (e.g. 2_000_000 for 2 Mbps).
+        max_framerate: Maximum frames per second (e.g. 15, 30).
+        resolution: Tuple of (width, height) for fallback frame. Default (640, 480).
+
+    Returns:
+        WebRTCStream instance with .push_frame() and .endpoint properties.
+    """
+    if getattr(self, "_started", False):
+      raise RuntimeError(
+        "create_webrtc_stream() must be called before app.start(). "
+        "WebRTC routes are registered during server startup."
+      )
+
+    from vuer.webrtc import WebRTCStreamManager
+
+    if self._webrtc_manager is None:
+      self._webrtc_manager = WebRTCStreamManager()
+    return self._webrtc_manager.create_stream(
+      stream_id, self,
+      track=track, codec=codec,
+      max_bitrate=max_bitrate, max_framerate=max_framerate,
+      resolution=resolution,
+    )
 
   async def relay(self, request):
     """This is the relay object for sending events to the server.
@@ -1316,8 +1359,8 @@ class Vuer(Server):
     self.start(free_port=free_port, *args, **kwargs)
 
   def start(self, free_port=None, *args, **kwargs):
-    # protocol, host, _ = self.uri.split(":")
-    # port = int(_)
+    self._started = True
+
     if free_port or self.free_port:
       import time
 
@@ -1361,6 +1404,23 @@ class Vuer(Server):
 
     self._add_route("/relay", self.relay, method="POST")
 
+    # Register WebRTC routes if any streams were created
+    if self._webrtc_manager is not None:
+      self._add_route(
+        "/webrtc/offer/{stream_id}", self._webrtc_manager.offer_handler, method="POST"
+      )
+      self._add_route("/webrtc/debug", self._webrtc_manager.debug_page_handler, method="GET")
+
+      async def _set_webrtc_loop(app):
+        self._webrtc_manager.set_loop(asyncio.get_running_loop())
+
+      self.app.on_startup.append(_set_webrtc_loop)
+
+      async def _shutdown_webrtc(app):
+        await self._webrtc_manager.cleanup_all()
+
+      self.app.on_shutdown.append(_shutdown_webrtc)
+
     if self.client_url:
       # the ssl is a property.
       base_url = self.client_url.format(
@@ -1375,6 +1435,22 @@ class Vuer(Server):
       workspace_lines.append(f" {DIM}·{RESET} file://{path}")
     workspace_display = "\n".join(workspace_lines)
 
+    # Format WebRTC stream info for display
+    webrtc_display = ""
+    if self._webrtc_manager is not None and self._webrtc_manager.streams:
+      proto = f"http{self.ssl}"
+      base = f"{proto}://{self.local_ip}:{self.port}"
+      webrtc_lines = []
+      for sid in self._webrtc_manager.streams:
+        offer_url = f"{base}/webrtc/offer/{sid}"
+        debug_url = f"{base}/webrtc/debug?url={offer_url}"
+        webrtc_lines.append(f" {DIM}·{RESET} {debug_url}")
+      webrtc_display = f"""
+{CYAN}WebRTC Streams:{RESET}
+
+{chr(10).join(webrtc_lines)}
+"""
+
     print(f"""{BOLD}Vuer Server{RESET}
 
 {CYAN}Local:{RESET}   {base_url}?ws=ws{self.ssl}://localhost:{self.port}
@@ -1384,7 +1460,7 @@ class Vuer(Server):
 
 {workspace_display}
 {DIM}->{RESET} {base_url}/workspace
-""")
+{webrtc_display}""")
 
     Server.start(self)
 

--- a/src/vuer/webrtc/__init__.py
+++ b/src/vuer/webrtc/__init__.py
@@ -17,6 +17,12 @@ from aiohttp import web
 _DEBUG_HTML_PATH = Path(__file__).parent / "debug.html"
 
 
+async def serve_debug_page(request):
+    """Serve the WebRTC debug page (standalone, no manager required)."""
+    html = _DEBUG_HTML_PATH.read_text()
+    return web.Response(content_type="text/html", text=html)
+
+
 def _require_aiortc():
     """Lazy import of aiortc dependencies with a clear error message."""
     try:
@@ -311,11 +317,6 @@ class WebRTCStreamManager:
                 content_type="application/json",
             )
         return await stream.handle_offer(request)
-
-    async def debug_page_handler(self, request):
-        """Serve the WebRTC debug page for verifying stream connectivity."""
-        html = _DEBUG_HTML_PATH.read_text()
-        return web.Response(content_type="text/html", text=html)
 
     def set_loop(self, loop):
         """Propagate event loop reference to all streams."""

--- a/src/vuer/webrtc/__init__.py
+++ b/src/vuer/webrtc/__init__.py
@@ -1,0 +1,332 @@
+"""WebRTC streaming support for Vuer.
+
+Provides BGRArrayVideoStreamTrack, WebRTCStream, and WebRTCStreamManager
+for hosting WebRTC video streams on Vuer's existing aiohttp server.
+
+Requires: pip install vuer[webrtc]
+"""
+
+import asyncio
+import fractions
+import json
+import time
+from pathlib import Path
+
+from aiohttp import web
+
+_DEBUG_HTML_PATH = Path(__file__).parent / "debug.html"
+
+
+def _require_aiortc():
+    """Lazy import of aiortc dependencies with a clear error message."""
+    try:
+        from aiortc import RTCPeerConnection, RTCSessionDescription
+        from aiortc.contrib.media import MediaRelay
+        from aiortc.rtcrtpsender import RTCRtpSender
+        import av
+
+        return RTCPeerConnection, RTCSessionDescription, MediaRelay, RTCRtpSender, av
+    except ImportError:
+        raise ImportError(
+            "WebRTC support requires aiortc and av. Install with: pip install vuer[webrtc]"
+        )
+
+
+def _make_track_class():
+    """Create BGRArrayVideoStreamTrack as a proper MediaStreamTrack subclass."""
+    from aiortc import MediaStreamTrack
+    import av as _av
+
+    class _BGRArrayVideoStreamTrack(MediaStreamTrack):
+        """MediaStreamTrack exposing BGR ndarrays as av.VideoFrame (latest-frame semantics)."""
+
+        kind = "video"
+
+        def __init__(self):
+            super().__init__()
+            self._queue: asyncio.Queue = asyncio.Queue(maxsize=1)
+            self._start_time = None
+            self._pts = 0
+            self._av = _av
+            self._fallback_resolution = (640, 480)  # (width, height), overridden by WebRTCStream
+
+        async def recv(self):
+            try:
+                frame = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                w, h = self._fallback_resolution
+                frame = self._av.VideoFrame(width=w, height=h, format="bgr24")
+                frame.pts = self._pts
+                frame.time_base = fractions.Fraction(1, 90000)
+            return frame
+
+        def push_frame(self, bgr_numpy, loop=None):
+            """Push a BGR numpy array as a video frame (thread-safe).
+
+            Args:
+                bgr_numpy: numpy array in BGR format (H, W, 3).
+                loop: asyncio event loop to schedule on.
+            """
+            if bgr_numpy is None:
+                return
+
+            try:
+                video_frame = self._av.VideoFrame.from_ndarray(bgr_numpy, format="bgr24")
+
+                if self._start_time is None:
+                    self._start_time = time.time()
+                    self._pts = 0
+                else:
+                    self._pts = int((time.time() - self._start_time) * 90000)
+
+                video_frame.pts = self._pts
+                video_frame.time_base = fractions.Fraction(1, 90000)
+            except Exception:
+                return
+
+            target_loop = loop or asyncio.get_event_loop()
+            if target_loop.is_closed():
+                return
+
+            def _put():
+                try:
+                    if self._queue.full():
+                        self._queue.get_nowait()
+                    self._queue.put_nowait(video_frame)
+                except Exception:
+                    pass
+
+            target_loop.call_soon_threadsafe(_put)
+
+    return _BGRArrayVideoStreamTrack
+
+
+def _apply_sdp_bitrate(sdp, max_kbps):
+    """Insert b=AS:<kbps> after each m=video line in the SDP."""
+    lines = sdp.split("\r\n")
+    result = []
+    for line in lines:
+        result.append(line)
+        if line.startswith("m=video"):
+            result.append(f"b=AS:{max_kbps}")
+    return "\r\n".join(result)
+
+
+def _apply_sdp_framerate(sdp, max_fps):
+    """Insert a=framerate:<fps> after each m=video line in the SDP."""
+    lines = sdp.split("\r\n")
+    result = []
+    for line in lines:
+        result.append(line)
+        if line.startswith("m=video"):
+            result.append(f"a=framerate:{max_fps}")
+    return "\r\n".join(result)
+
+
+class WebRTCStream:
+    """A single WebRTC stream that can serve video to multiple peers.
+
+    Two usage modes:
+    - High-level: omit track, use push_frame(bgr_numpy) to send frames.
+    - Low-level: provide a custom track, frames come from the track itself.
+    """
+
+    def __init__(
+        self,
+        stream_id,
+        vuer,
+        track=None,
+        codec="H264",
+        max_bitrate=None,
+        max_framerate=None,
+        resolution=None,
+    ):
+        """
+        Args:
+            stream_id: Unique identifier for the stream.
+            vuer: The Vuer server instance.
+            track: Optional custom MediaStreamTrack. If None, creates an
+                   internal track and enables push_frame().
+            codec: Preferred codec ("H264" or "VP8"). Default "H264".
+            max_bitrate: Maximum bitrate in bps (e.g. 2_000_000 for 2 Mbps).
+                         None means encoder default.
+            max_framerate: Maximum frames per second (e.g. 15, 30).
+                           None means no limit.
+            resolution: Tuple of (width, height) for the black fallback frame
+                        when no frames are being pushed. Default (640, 480).
+        """
+        RTCPeerConnection, RTCSessionDescription, MediaRelay, RTCRtpSender, av = _require_aiortc()
+
+        self.stream_id = stream_id
+        self._vuer = vuer
+        self._codec = (codec or "H264").lower()
+        self._max_bitrate = max_bitrate
+        self._max_framerate = max_framerate
+        self._resolution = resolution or (640, 480)
+        self._pcs = set()
+        self._relay = MediaRelay()
+        self._loop = None
+
+        if track is None:
+            TrackClass = _make_track_class()
+            self._internal_track = TrackClass()
+            self._internal_track._fallback_resolution = self._resolution
+            self._track = self._internal_track
+        else:
+            self._internal_track = None
+            self._track = track
+
+    @property
+    def ready(self):
+        """Whether the stream's event loop has been set (server is running)."""
+        return self._loop is not None
+
+    def wait_ready_sync(self, timeout=10):
+        """Block the current thread until the stream is ready.
+
+        Args:
+            timeout: Maximum seconds to wait. Raises TimeoutError if exceeded.
+        """
+        deadline = time.time() + timeout
+        while not self.ready:
+            if time.time() > deadline:
+                raise TimeoutError(
+                    f"WebRTC stream '{self.stream_id}' not ready after {timeout}s. "
+                    "Is the server running?"
+                )
+            time.sleep(0.05)
+
+    def push_frame(self, bgr_numpy):
+        """Push a BGR numpy frame to the stream (thread-safe).
+
+        Only available when no custom track was provided.
+        """
+        if self._internal_track is None:
+            raise RuntimeError(
+                "push_frame() is not available when a custom track is provided. "
+                "The custom track produces its own frames."
+            )
+        self._internal_track.push_frame(bgr_numpy, loop=self._loop)
+
+    @property
+    def endpoint(self):
+        """Full URL for this stream's offer endpoint."""
+        v = self._vuer
+        proto = "https" if v.cert else "http"
+        host = v.local_ip if v.host == "0.0.0.0" else v.host
+        return f"{proto}://{host}:{v.port}/webrtc/offer/{self.stream_id}"
+
+    @property
+    def url(self):
+        """Path-only URL for this stream's offer endpoint."""
+        return f"/webrtc/offer/{self.stream_id}"
+
+    async def handle_offer(self, request):
+        """Handle an SDP offer and return an SDP answer."""
+        RTCPeerConnection, RTCSessionDescription, MediaRelay, RTCRtpSender, av = _require_aiortc()
+
+        params = await request.json()
+        offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+        pc = RTCPeerConnection()
+        self._pcs.add(pc)
+
+        # Subscribe via relay so encoding happens once globally
+        relayed_track = self._relay.subscribe(self._track)
+        transceiver = pc.addTransceiver(relayed_track, direction="sendonly")
+
+        # Set codec preferences
+        capabilities = RTCRtpSender.getCapabilities("video")
+        codec = self._codec
+        codec_map = {"h264": "video/H264", "vp8": "video/VP8"}
+        mime = codec_map.get(codec, "video/H264")
+        preferred = [c for c in capabilities.codecs if c.mimeType == mime]
+        if preferred:
+            transceiver.setCodecPreferences(preferred)
+
+        @pc.on("connectionstatechange")
+        async def on_connectionstatechange():
+            if pc.connectionState in ("failed", "closed"):
+                self._pcs.discard(pc)
+                await pc.close()
+
+        await pc.setRemoteDescription(offer)
+        answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+
+        sdp = pc.localDescription.sdp
+
+        # Apply bitrate constraint via SDP b=AS: line (kbps)
+        if self._max_bitrate is not None:
+            max_kbps = self._max_bitrate // 1000
+            sdp = _apply_sdp_bitrate(sdp, max_kbps)
+
+        # Apply framerate constraint via SDP a=framerate: line
+        if self._max_framerate is not None:
+            sdp = _apply_sdp_framerate(sdp, self._max_framerate)
+
+        return web.Response(
+            content_type="application/json",
+            text=json.dumps(
+                {"sdp": sdp, "type": pc.localDescription.type}
+            ),
+        )
+
+    def set_loop(self, loop):
+        self._loop = loop
+
+    async def cleanup(self):
+        """Close all peer connections for this stream."""
+        coros = [pc.close() for pc in self._pcs]
+        self._pcs.clear()
+        for coro in coros:
+            try:
+                await coro
+            except Exception:
+                pass
+
+
+class WebRTCStreamManager:
+    """Manages multiple WebRTC streams and dispatches offer requests."""
+
+    def __init__(self):
+        self._streams = {}
+
+    def create_stream(self, stream_id, vuer, **kwargs):
+        """Create and register a new WebRTC stream."""
+        if stream_id in self._streams:
+            raise ValueError(f"WebRTC stream '{stream_id}' already exists")
+        stream = WebRTCStream(stream_id, vuer, **kwargs)
+        self._streams[stream_id] = stream
+        return stream
+
+    async def offer_handler(self, request):
+        """Route handler for /webrtc/offer/{stream_id}."""
+        stream_id = request.match_info["stream_id"]
+        stream = self._streams.get(stream_id)
+        if stream is None:
+            return web.Response(
+                status=404,
+                text=json.dumps({"error": f"Stream '{stream_id}' not found"}),
+                content_type="application/json",
+            )
+        return await stream.handle_offer(request)
+
+    async def debug_page_handler(self, request):
+        """Serve the WebRTC debug page for verifying stream connectivity."""
+        html = _DEBUG_HTML_PATH.read_text()
+        return web.Response(content_type="text/html", text=html)
+
+    def set_loop(self, loop):
+        """Propagate event loop reference to all streams."""
+        for stream in self._streams.values():
+            stream.set_loop(loop)
+
+    @property
+    def streams(self):
+        return dict(self._streams)
+
+    async def cleanup_all(self):
+        """Cleanup all streams."""
+        for stream in self._streams.values():
+            await stream.cleanup()

--- a/src/vuer/webrtc/debug.html
+++ b/src/vuer/webrtc/debug.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Vuer WebRTC Debug</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #1a1a2e; color: #eee; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; min-height: 100vh; padding: 20px;
+  }
+  h1 { font-size: 1.4em; margin-bottom: 16px; color: #7dd3fc; }
+  .controls {
+    display: flex; gap: 8px; align-items: center; margin-bottom: 16px; flex-wrap: wrap;
+    justify-content: center;
+  }
+  input[type=text] {
+    width: 420px; padding: 8px 12px; border-radius: 6px; border: 1px solid #444;
+    background: #16213e; color: #eee; font-size: 14px; font-family: monospace;
+  }
+  button {
+    padding: 8px 20px; border-radius: 6px; border: none; font-size: 14px;
+    cursor: pointer; font-weight: 600; transition: background 0.2s;
+  }
+  #start { background: #22c55e; color: #000; }
+  #start:hover { background: #16a34a; }
+  #stop { background: #ef4444; color: #fff; display: none; }
+  #stop:hover { background: #dc2626; }
+  #status {
+    padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600;
+  }
+  .status-idle { background: #334155; color: #94a3b8; }
+  .status-connecting { background: #854d0e; color: #fde68a; }
+  .status-connected { background: #166534; color: #86efac; }
+  .status-failed { background: #7f1d1d; color: #fca5a5; }
+  video {
+    max-width: 90vw; max-height: 70vh; border-radius: 8px;
+    background: #000; border: 2px solid #334155;
+  }
+</style>
+</head>
+<body>
+<h1>Vuer WebRTC Debug</h1>
+<div class="controls">
+  <input type="text" id="url" placeholder="Offer URL">
+  <button id="start" onclick="start()">Start</button>
+  <button id="stop" onclick="stop()">Stop</button>
+  <span id="status" class="status-idle">Idle</span>
+</div>
+<video id="video" autoplay playsinline muted></video>
+
+<script>
+var pc = null;
+
+(function() {
+  var params = new URLSearchParams(window.location.search);
+  var urlParam = params.get('url');
+  if (urlParam) {
+    document.getElementById('url').value = urlParam;
+  } else {
+    var loc = window.location;
+    document.getElementById('url').value =
+      loc.protocol + '//' + loc.host + '/webrtc/offer/default';
+  }
+})();
+
+function setStatus(state, text) {
+  var el = document.getElementById('status');
+  el.textContent = text;
+  el.className = 'status-' + state;
+}
+
+function negotiate(url) {
+  pc.addTransceiver('video', { direction: 'recvonly' });
+  return pc.createOffer().then(function(offer) {
+    return pc.setLocalDescription(offer);
+  }).then(function() {
+    return new Promise(function(resolve) {
+      if (pc.iceGatheringState === 'complete') {
+        resolve();
+      } else {
+        var checkState = function() {
+          if (pc.iceGatheringState === 'complete') {
+            pc.removeEventListener('icegatheringstatechange', checkState);
+            resolve();
+          }
+        };
+        pc.addEventListener('icegatheringstatechange', checkState);
+      }
+    });
+  }).then(function() {
+    var offer = pc.localDescription;
+    return fetch(url, {
+      body: JSON.stringify({ sdp: offer.sdp, type: offer.type }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST'
+    });
+  }).then(function(response) {
+    return response.json();
+  }).then(function(answer) {
+    return pc.setRemoteDescription(answer);
+  }).catch(function(e) {
+    setStatus('failed', 'Error: ' + e);
+  });
+}
+
+function start() {
+  var url = document.getElementById('url').value;
+  if (!url) { alert('Enter an offer URL'); return; }
+
+  setStatus('connecting', 'Connecting...');
+
+  pc = new RTCPeerConnection({ sdpSemantics: 'unified-plan' });
+
+  pc.addEventListener('connectionstatechange', function() {
+    if (pc.connectionState === 'connected') {
+      setStatus('connected', 'Connected');
+    } else if (pc.connectionState === 'failed') {
+      setStatus('failed', 'Failed');
+    }
+  });
+
+  pc.addEventListener('track', function(evt) {
+    if (evt.track.kind === 'video') {
+      document.getElementById('video').srcObject = evt.streams[0];
+    }
+  });
+
+  document.getElementById('start').style.display = 'none';
+  document.getElementById('stop').style.display = 'inline-block';
+  negotiate(url);
+}
+
+function stop() {
+  document.getElementById('stop').style.display = 'none';
+  document.getElementById('start').style.display = 'inline-block';
+  setStatus('idle', 'Idle');
+  if (pc) {
+    pc.close();
+    pc = null;
+  }
+  document.getElementById('video').srcObject = null;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Fix graceful shutdown** (`base.py`): `Server.start()` now properly handles `KeyboardInterrupt` — calls `runner.cleanup()` (triggering `on_shutdown` hooks), cancels pending async tasks, and closes the event loop. Previously required double Ctrl+C / SIGKILL to terminate, and resources like cameras were never released.

https://github.com/user-attachments/assets/c2452c8a-b803-4d1c-974c-d5bc69b7332a



- **Add WebRTC streaming module** (`src/vuer/webrtc/`): Integrates WebRTC video streaming into Vuer's existing aiohttp server. Two usage modes:
  - **High-level**: `stream = app.create_webrtc_stream("id")` + `stream.push_frame(bgr_numpy)` from any thread
  - **Low-level**: pass a custom `MediaStreamTrack` (e.g. from `aiortc.MediaPlayer`) directly

- **Configurable stream parameters** (all optional):
  - `codec`: H264 (default) or VP8
  - `max_bitrate`: limit via SDP `b=AS:` (e.g. `2_000_000` for 2 Mbps)
  - `max_framerate`: limit via SDP `a=framerate:` (e.g. `15`)
  - `resolution`: fallback black frame size when no frames are pushed

- **Debug page** (`/webrtc/debug`): browser-based WebRTC player with `?url=` query param support. Server startup prints clickable debug URLs per stream.

- **3 examples** in `docs/examples/webrtc/`:
  - `push_frame.py` — push numpy frames from a thread
  - `custom_track.py` — bind USB camera via aiortc MediaPlayer
  - `standalone_server.py` — bare aiohttp+aiortc reference (no Vuer)

- **Optional dependency**: `pip install vuer[webrtc]` installs `aiortc>=1.6.0` and `av>=10.0.0`

## Test plan

- [ ] Run `push_frame.py`, open debug URL, verify scrolling color blocks
- [ ] Run `custom_track.py`, open debug URL, verify camera feed, Ctrl+C exits cleanly
- [ ] Run `standalone_server.py`, connect from a Vuer debug page on another port
- [ ] Test cross-machine: run WebRTC server on machine A, pass `src="http://A:port/webrtc/offer/id"` to `WebRTCVideoPlane` on machine B
- [ ] Verify `create_webrtc_stream()` after `start()` raises `RuntimeError`